### PR TITLE
Add initial TrueAsync RFC

### DIFF
--- a/TrueAsyncRFC
+++ b/TrueAsyncRFC
@@ -1,12 +1,16 @@
 # TrueAsync API RFC
 
 ## Introduction
-The **TrueAsync API** introduces a pluggable framework for asynchronous programming in PHP. It allows extensions to register their own scheduler, reactor and thread pool implementations while keeping the Zend Engine independent of any particular event loop library.
+The **TrueAsync API** introduces a pluggable framework for asynchronous programming in PHP. It allows extensions to register their own scheduler, reactor and thread pool implementations while keeping the Zend Engine independent of any particular event loop library. The primary goal is to separate the core PHP functions from any specific asynchronous backend so that alternative implementations can be swapped in without modifying the engine.
 
 ## Motivation
 Prior to this branch, `master` lacked a unified asynchronous interface. The `work` branch adds two new core files, `Zend/zend_async_API.c` and `Zend/zend_async_API.h`, and integrates them into the engine. Supporting files such as `main/network_async.c` and documentation under `docs/source/true_async_api` are also included. These changes enable non‑blocking operations and cancellation handling across the core.
 - Including the API in the core ensures all extensions share the same asynchronous primitives and allows built-in features like cancellation to function consistently.
 - Concrete implementations may live in separate extensions such as libuv wrappers.
+The API is part of the Zend Engine for the following reasons:
+1. As a core module it is available before extension initialization, enabling schedulers and reactors to cooperate correctly.
+2. Core functions and extensions can always reference its symbols regardless of whether a backend is installed.
+3. The garbage collector uses it to run cycle collection in its own coroutine so that user code is not blocked while destroying cycles.
 
 ## Specification
 ### API Definition
@@ -50,6 +54,9 @@ When the API is active, several built-in functions delegate to the wrappers abov
 - A new `CancellationException` class is registered via `Zend/zend_exceptions.c`.
 - Network functions call async counterparts from `main/network_async.c` when available.
 - The API is disabled by default; if no backend is registered all stubs throw errors.
+
+### Garbage Collector Integration
+The garbage collector schedules cycle destruction using the async API. When a cycle is detected, it spawns a coroutine that runs the destructor chain through the registered scheduler. This keeps asynchronous tasks responsive while cyclic references are collected.
 
 ## Impact on Core
 The API keeps implementation details out of the Zend Engine. Extensions may implement async features using `libuv` or other libraries and register them during module initialization. When enabled, coroutine management and I/O polling are delegated to those backends while the engine interacts only through the standardized interfaces.

--- a/TrueAsyncRFC
+++ b/TrueAsyncRFC
@@ -1,0 +1,37 @@
+# TrueAsync API RFC
+
+## Introduction
+The **TrueAsync API** introduces a pluggable framework for asynchronous programming in PHP. It allows extensions to register their own scheduler, reactor and thread pool implementations while keeping the Zend Engine independent of any particular event loop library.
+
+## Motivation
+Prior to this branch, `master` lacked a unified asynchronous interface. The `work` branch adds two new core files, `Zend/zend_async_API.c` and `Zend/zend_async_API.h`, and integrates them into the engine. Supporting files such as `main/network_async.c` and documentation under `docs/source/true_async_api` are also included. These changes enable non‑blocking operations and cancellation handling across the core.
+
+## Specification
+### API Definition
+- Located in `Zend/zend_async_API.h` and implemented in `Zend/zend_async_API.c`.
+- Defines function pointers and structures for events, coroutines, scopes and wakers.
+- Provides registration functions for:
+  - Scheduler (`zend_async_scheduler_register`)
+  - Reactor (`zend_async_reactor_register`)
+  - Thread pool (`zend_async_thread_pool_register`)
+- Exposes macros such as `ZEND_ASYNC_GETADDRINFO` and event reference counters.
+
+### Integration with Core
+- `Zend/zend.c` and other core files now include the header when `PHP_ASYNC_API` is defined.
+- A new `CancellationException` class is registered via `Zend/zend_exceptions.c`.
+- Network functions call async counterparts from `main/network_async.c` when available.
+- The API is disabled by default; if no backend is registered all stubs throw errors.
+
+## Impact on Core
+The API keeps implementation details out of the Zend Engine. Extensions may implement async features using `libuv` or other libraries and register them during module initialization. When enabled, coroutine management and I/O polling are delegated to those backends while the engine interacts only through the standardized interfaces.
+
+## Backward Compatibility
+When no backend is loaded, the stubs simply throw runtime errors so behavior matches that of the `master` branch. Existing extensions remain unaffected unless they opt in by using the new API.
+
+## Future Scope
+Further work may extend the API with higher level abstractions, additional event types and tighter integration with PHP Fibers. Documentation continues to evolve under `docs/source/true_async_api`.
+
+## References
+- `Zend/zend_async_API.h`
+- `Zend/zend_async_API.c`
+- `docs/source/true_async_api/*`

--- a/TrueAsyncRFC
+++ b/TrueAsyncRFC
@@ -38,6 +38,18 @@ Networking wrappers exported from `main/network_async.c` include:
 - `php_network_gethostbyname_async`
 - `php_network_gethostbyaddr_async`
 - `php_network_getaddresses_async`
+### Architecture Overview
+The API defines four foundational types used by all asynchronous backends.
+
+**Events** are the low-level representation of sockets, timers and other sources of readiness. They store callbacks and are started or stopped by the reactor. Reference counters and macros manage their lifetime.
+
+**Coroutines** are stackful tasks built on Zend Fibers. Every coroutine has an associated **waker** and belongs to a **scope**. The scheduler resumes or cancels coroutines via their wakers and dispatches them according to their scope.
+
+**Scopes** form a hierarchy for coroutine lifetime management. A scope remains alive while any of its coroutines run, enabling grouped cancellation and cleanup hooks.
+
+**Wakers** hold triggered events along with a result or error. They ensure a suspended coroutine resumes exactly once when its events complete or are cancelled.
+These primitives let different reactors and schedulers interoperate without coupling the engine to one implementation.
+
 
 ### Affected PHP Functions
 When the API is active, several built-in functions delegate to the wrappers above:

--- a/TrueAsyncRFC
+++ b/TrueAsyncRFC
@@ -26,6 +26,7 @@ The following functions and macros form the public interface:
 - `ZEND_ASYNC_NEW_SOCKET_EVENT`, `ZEND_ASYNC_NEW_TIMER_EVENT`, `ZEND_ASYNC_EXEC`
 - `ZEND_ASYNC_QUEUE_TASK`
 
+
 Networking wrappers exported from `main/network_async.c` include:
 - `php_poll2_async`
 - `php_select_async`
@@ -33,6 +34,15 @@ Networking wrappers exported from `main/network_async.c` include:
 - `php_network_gethostbyname_async`
 - `php_network_gethostbyaddr_async`
 - `php_network_getaddresses_async`
+
+### Affected PHP Functions
+When the API is active, several built-in functions delegate to the wrappers above:
+- `fsockopen()` and `pfsockopen()`
+- `stream_socket_client()` and `stream_socket_server()`
+- `stream_select()`
+- `gethostbyaddr()`, `gethostbyname()` and `gethostbynamel()`
+- `socket_addrinfo_lookup()`, `socket_addrinfo_bind()` and `socket_addrinfo_connect()`
+- Networking routines in the FTP and PgSQL extensions, which rely on `php_poll2()`
 
 
 ### Integration with Core

--- a/TrueAsyncRFC
+++ b/TrueAsyncRFC
@@ -5,6 +5,8 @@ The **TrueAsync API** introduces a pluggable framework for asynchronous programm
 
 ## Motivation
 Prior to this branch, `master` lacked a unified asynchronous interface. The `work` branch adds two new core files, `Zend/zend_async_API.c` and `Zend/zend_async_API.h`, and integrates them into the engine. Supporting files such as `main/network_async.c` and documentation under `docs/source/true_async_api` are also included. These changes enable non‑blocking operations and cancellation handling across the core.
+- Including the API in the core ensures all extensions share the same asynchronous primitives and allows built-in features like cancellation to function consistently.
+- Concrete implementations may live in separate extensions such as libuv wrappers.
 
 ## Specification
 ### API Definition
@@ -15,6 +17,23 @@ Prior to this branch, `master` lacked a unified asynchronous interface. The `wor
   - Reactor (`zend_async_reactor_register`)
   - Thread pool (`zend_async_thread_pool_register`)
 - Exposes macros such as `ZEND_ASYNC_GETADDRINFO` and event reference counters.
+### API Functions
+The following functions and macros form the public interface:
+- `zend_async_scheduler_register`
+- `zend_async_reactor_register`
+- `zend_async_thread_pool_register`
+- `zend_async_event_callback_new` and `zend_async_event_callback_dispose`
+- `ZEND_ASYNC_NEW_SOCKET_EVENT`, `ZEND_ASYNC_NEW_TIMER_EVENT`, `ZEND_ASYNC_EXEC`
+- `ZEND_ASYNC_QUEUE_TASK`
+
+Networking wrappers exported from `main/network_async.c` include:
+- `php_poll2_async`
+- `php_select_async`
+- `php_network_getaddrinfo_async`
+- `php_network_gethostbyname_async`
+- `php_network_gethostbyaddr_async`
+- `php_network_getaddresses_async`
+
 
 ### Integration with Core
 - `Zend/zend.c` and other core files now include the header when `PHP_ASYNC_API` is defined.

--- a/TrueAsyncRFC
+++ b/TrueAsyncRFC
@@ -50,10 +50,19 @@ When the API is active, several built-in functions delegate to the wrappers abov
 
 
 ### Integration with Core
-- `Zend/zend.c` and other core files now include the header when `PHP_ASYNC_API` is defined.
-- A new `CancellationException` class is registered via `Zend/zend_exceptions.c`.
+- `Zend/zend.c` and related files now include the header when `PHP_ASYNC_API` is defined.
 - Network functions call async counterparts from `main/network_async.c` when available.
 - The API is disabled by default; if no backend is registered all stubs throw errors.
+
+### CancellationException
+`CancellationException` lives alongside `Exception` but does not extend it. Its
+sole purpose is to signal coroutine cancellation. Making it a root exception
+ensures that generic `catch (Exception $e)` blocks do not intercept it
+accidentally. The class is defined in the core because fundamental engine
+functions such as `zend_throw_exception_internal()`, `zend_handle_exception()`
+and `zend_error_va_list()` assume that all throwable types are known at startup.
+Changing their logic from extensions would be brittle, so the cancellation class
+is registered by the engine itself.
 
 ### Garbage Collector Integration
 The garbage collector schedules cycle destruction using the async API. When a cycle is detected, it spawns a coroutine that runs the destructor chain through the registered scheduler. This keeps asynchronous tasks responsive while cyclic references are collected.


### PR DESCRIPTION
## Summary
- add an RFC document describing the new TrueAsync API

## Testing
- `php -v` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68430bbab5a0832b8e9651f06f819d71