### PR TITLE
#136 ext/curl + ext/pdo: fixes under coroutine cancellation

### DIFF
--- a/ext/curl/curl_async.c
+++ b/ext/curl/curl_async.c
@@ -1979,6 +1979,7 @@ static void curl_async_write_user_complete(
 		&& state->has_pending_result && state->pending_result != ZSTR_LEN(state->write_data)) {
 		curl_event->done_result = CURLE_WRITE_ERROR;
 		user_abort = true;
+		state->aborted = true;
 	}
 
 	/* Release the zend_string */
@@ -2042,7 +2043,7 @@ static void curl_async_write_user_complete(
  */
 size_t curl_async_write_user(char *data, const size_t size, const size_t nmemb, php_curl *ch, const bool is_header)
 {
-	const size_t length = size * nmemb;
+	size_t length = size * nmemb;
 
 	curl_async_event_t *curl_event = (curl_async_event_t *) ch->async_event;
 	if (curl_event == NULL) {
@@ -2103,11 +2104,34 @@ size_t curl_async_write_user(char *data, const size_t size, const size_t nmemb, 
 
 	curl_async_write_state_t *state = is_header ? curl_event->header_write_state : curl_event->write_state;
 
-	/* Re-call after async completion — return stored result */
+	/* Re-call after async completion of a paused slice. */
 	if (state != NULL && state->has_pending_result) {
-		const size_t result = state->pending_result;
 		state->has_pending_result = false;
-		return result;
+
+		/* The PHP callback aborted (short return / exception) — surface the
+		 * stored result verbatim so libcurl raises CURLE_WRITE_ERROR. */
+		if (state->aborted) {
+			const size_t result = state->pending_result;
+			state->aborted = false;
+			state->consumed_offset = 0;
+			return result;
+		}
+
+		/* The finished slice was accepted in full. libcurl re-delivers the
+		 * whole paused window on unpause and may coalesce freshly decoded
+		 * data into it (notably with chunked transfer-encoding), so this
+		 * re-call can carry more bytes than the slice paused on. Advance
+		 * through the window; report the full length back to libcurl only
+		 * once the PHP callback has accepted every byte of it — otherwise
+		 * feed the remainder through another callback slice below. */
+		state->consumed_offset += state->pending_result;
+		if (state->consumed_offset >= length) {
+			state->consumed_offset = 0;
+			return length;
+		}
+		data   += state->consumed_offset;
+		length -= state->consumed_offset;
+		/* fall through to spawn a callback for the rest of the window */
 	}
 
 	/* Lazy init state */

--- a/ext/curl/curl_async.h
+++ b/ext/curl/curl_async.h
@@ -109,6 +109,17 @@ struct curl_async_write_state_s {
 	bool has_pending_result;
 	size_t pending_result;
 
+	/* Bytes of the current re-call window already accepted by the PHP
+	 * callback. On unpause libcurl re-delivers the whole paused window and
+	 * may coalesce freshly decoded data into it (notably with chunked
+	 * transfer-encoding), so a re-call can carry more bytes than the slice
+	 * that was paused on; this tracks progress through such a window. */
+	size_t consumed_offset;
+
+	/* True when the PHP callback signalled an abort (short return or
+	 * exception): the pending re-call must surface pending_result verbatim. */
+	bool aborted;
+
 	/* True between returning CURL_WRITEFUNC_PAUSE and completion callback */
 	bool pending;
 

--- a/ext/pdo/pdo_dbh.c
+++ b/ext/pdo/pdo_dbh.c
@@ -1312,8 +1312,9 @@ PHP_METHOD(PDO, errorCode)
 
 	PDO_CONSTRUCT_CHECK;
 
-	if (dbh->query_stmt) {
-		RETURN_STRING(dbh->query_stmt->error_code);
+	pdo_stmt_t *failed_stmt = pdo_dbh_get_last_failed_query_stmt(dbh);
+	if (failed_stmt) {
+		RETURN_STRING(failed_stmt->error_code);
 	}
 
 	if (dbh->error_code[0] == '\0') {
@@ -1343,9 +1344,10 @@ PHP_METHOD(PDO, errorInfo)
 
 	array_init(return_value);
 
-	if (dbh->query_stmt) {
-		add_next_index_string(return_value, dbh->query_stmt->error_code);
-		if(!strncmp(dbh->query_stmt->error_code, PDO_ERR_NONE, sizeof(PDO_ERR_NONE))) goto fill_array;
+	pdo_stmt_t *failed_stmt = pdo_dbh_get_last_failed_query_stmt(dbh);
+	if (failed_stmt) {
+		add_next_index_string(return_value, failed_stmt->error_code);
+		if(!strncmp(failed_stmt->error_code, PDO_ERR_NONE, sizeof(PDO_ERR_NONE))) goto fill_array;
 	} else {
 		add_next_index_string(return_value, dbh->error_code);
 		if(!strncmp(dbh->error_code, PDO_ERR_NONE, sizeof(PDO_ERR_NONE))) goto fill_array;
@@ -1355,7 +1357,7 @@ PHP_METHOD(PDO, errorInfo)
 		/* Route fetch_err through existing slot connection (peek, never acquire) */
 		pdo_dbh_t *err_conn = pdo_pool_peek_conn(dbh);
 		if (err_conn && err_conn->methods && err_conn->methods->fetch_err) {
-			err_conn->methods->fetch_err(err_conn, dbh->query_stmt, return_value);
+			err_conn->methods->fetch_err(err_conn, failed_stmt, return_value);
 		}
 	}
 
@@ -1456,8 +1458,7 @@ PHP_METHOD(PDO, query)
 			}
 		}
 		/* something broke */
-		dbh->query_stmt = stmt;
-		dbh->query_stmt_obj = Z_OBJ_P(return_value);
+		pdo_dbh_set_last_failed_query_stmt(dbh, stmt, Z_OBJ_P(return_value));
 		GC_DELREF(stmt->database_object_handle);
 		stmt->database_object_handle = NULL;
 		pdo_pool_sync_error(dbh, conn);
@@ -1762,14 +1763,9 @@ static void dbh_free(pdo_dbh_t *dbh, bool free_persistent)
 {
 	int i;
 
-	/* Release cached query statement before pool — it may hold a pooled_conn pointer */
-	if (dbh->query_stmt) {
-		OBJ_RELEASE(dbh->query_stmt_obj);
-		dbh->query_stmt_obj = NULL;
-		dbh->query_stmt = NULL;
-	}
+	/* Release stash before pool — its stmt may reference a pooled conn. */
+	pdo_dbh_release_last_failed_query_stmt(dbh);
 
-	/* Destroy connection pool */
 	pdo_pool_destroy(dbh);
 
 	if (dbh->is_persistent) {

--- a/ext/pdo/pdo_dbh.c
+++ b/ext/pdo/pdo_dbh.c
@@ -71,7 +71,7 @@ PDO_API bool php_pdo_stmt_valid_db_obj_handle(const pdo_stmt_t *stmt)
 
 void pdo_raise_impl_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt, pdo_error_type sqlstate, const char *supp) /* {{{ */
 {
-	pdo_error_type *pdo_err = &dbh->error_code;
+	pdo_error_type *pdo_err = pdo_dbh_error_code(dbh);
 	const char *msg;
 
 	if (dbh->error_mode == PDO_ERRMODE_SILENT) {
@@ -129,7 +129,7 @@ void pdo_raise_impl_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt, pdo_error_type sqlst
 
 PDO_API void pdo_handle_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt) /* {{{ */
 {
-	pdo_error_type *pdo_err = &dbh->error_code;
+	pdo_error_type *pdo_err = pdo_dbh_error_code(dbh);
 	const char *msg = "<<Unknown>>";
 	char *supp = NULL;
 	zend_long native_code = 0;
@@ -1317,15 +1317,12 @@ PHP_METHOD(PDO, errorCode)
 		RETURN_STRING(failed_stmt->error_code);
 	}
 
-	if (dbh->error_code[0] == '\0') {
+	pdo_error_type *err = pdo_dbh_error_code(dbh);
+	if ((*err)[0] == '\0') {
 		RETURN_NULL();
 	}
 
-	/**
-	 * Making sure that we fallback to the default implementation
-	 * if the dbh->error_code is not null.
-	 */
-	RETURN_STRING(dbh->error_code);
+	RETURN_STRING(*err);
 }
 /* }}} */
 
@@ -1349,8 +1346,9 @@ PHP_METHOD(PDO, errorInfo)
 		add_next_index_string(return_value, failed_stmt->error_code);
 		if(!strncmp(failed_stmt->error_code, PDO_ERR_NONE, sizeof(PDO_ERR_NONE))) goto fill_array;
 	} else {
-		add_next_index_string(return_value, dbh->error_code);
-		if(!strncmp(dbh->error_code, PDO_ERR_NONE, sizeof(PDO_ERR_NONE))) goto fill_array;
+		pdo_error_type *err = pdo_dbh_error_code(dbh);
+		add_next_index_string(return_value, *err);
+		if(!strncmp(*err, PDO_ERR_NONE, sizeof(PDO_ERR_NONE))) goto fill_array;
 	}
 
 	if (dbh->methods->fetch_err) {

--- a/ext/pdo/pdo_pool.c
+++ b/ext/pdo/pdo_pool.c
@@ -52,18 +52,77 @@ typedef struct {
 	pdo_dbh_t *conn;                    /* active connection, NULL if released back to pool */
 	zend_ulong coro_key;                /* key in pool_bindings */
 	bool has_coro_callback;              /* true if registered with coroutine event */
+
+	pdo_stmt_t  *last_failed_query_stmt;
+	zend_object *last_failed_query_stmt_obj;
 } pdo_pool_binding_t;
 
-/* Reset error state on the template dbh.
- * Called on acquire so a new coroutine never sees stale errors. */
-static void pdo_pool_reset_error(pdo_dbh_t *dbh)
+static void pdo_pool_binding_release_query_stmt(pdo_pool_binding_t *binding)
 {
-	memcpy(dbh->error_code, PDO_ERR_NONE, sizeof(pdo_error_type));
+	if (binding->last_failed_query_stmt_obj != NULL) {
+		OBJ_RELEASE(binding->last_failed_query_stmt_obj);
+		binding->last_failed_query_stmt_obj = NULL;
+		binding->last_failed_query_stmt = NULL;
+	}
+}
 
-	if (dbh->query_stmt) {
-		OBJ_RELEASE(dbh->query_stmt_obj);
-		dbh->query_stmt_obj = NULL;
-		dbh->query_stmt = NULL;
+static pdo_pool_binding_t *pdo_pool_current_binding(pdo_dbh_t *dbh)
+{
+	if (dbh->pool == NULL || dbh->pool_bindings == NULL) {
+		return NULL;
+	}
+	zend_coroutine_t *coro = ZEND_ASYNC_CURRENT_COROUTINE;
+	if (coro == NULL) {
+		return NULL;
+	}
+	return zend_hash_index_find_ptr(dbh->pool_bindings, pdo_pool_coro_key(coro));
+}
+
+pdo_stmt_t *pdo_dbh_get_last_failed_query_stmt(pdo_dbh_t *dbh)
+{
+	if (dbh->pool == NULL) {
+		return dbh->last_failed_query_stmt;
+	}
+	pdo_pool_binding_t *binding = pdo_pool_current_binding(dbh);
+	return binding ? binding->last_failed_query_stmt : NULL;
+}
+
+void pdo_dbh_set_last_failed_query_stmt(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zend_object *obj)
+{
+	if (dbh->pool == NULL) {
+		if (dbh->last_failed_query_stmt_obj != NULL) {
+			OBJ_RELEASE(dbh->last_failed_query_stmt_obj);
+		}
+		dbh->last_failed_query_stmt = stmt;
+		dbh->last_failed_query_stmt_obj = obj;
+		return;
+	}
+	/* No binding (shouldn't happen — caller just acquired conn): silently
+	 * skip the stash. We do NOT OBJ_RELEASE(obj) — caller still uses stmt. */
+	pdo_pool_binding_t *binding = pdo_pool_current_binding(dbh);
+	if (UNEXPECTED(binding == NULL)) {
+		return;
+	}
+	if (binding->last_failed_query_stmt_obj != NULL) {
+		OBJ_RELEASE(binding->last_failed_query_stmt_obj);
+	}
+	binding->last_failed_query_stmt = stmt;
+	binding->last_failed_query_stmt_obj = obj;
+}
+
+void pdo_dbh_release_last_failed_query_stmt(pdo_dbh_t *dbh)
+{
+	if (dbh->pool == NULL) {
+		if (dbh->last_failed_query_stmt_obj != NULL) {
+			OBJ_RELEASE(dbh->last_failed_query_stmt_obj);
+			dbh->last_failed_query_stmt_obj = NULL;
+			dbh->last_failed_query_stmt = NULL;
+		}
+		return;
+	}
+	pdo_pool_binding_t *binding = pdo_pool_current_binding(dbh);
+	if (binding != NULL) {
+		pdo_pool_binding_release_query_stmt(binding);
 	}
 }
 
@@ -244,15 +303,11 @@ static void pdo_pool_binding_on_coroutine_finish(
 		return;
 	}
 
-	/* Clear stale error state on template BEFORE release — query_stmt may
-	 * reference the pooled conn via pooled_conn pointer, and release with
-	 * conn_broken will destroy the conn. Must release query_stmt first. */
-	pdo_pool_reset_error(binding->dbh);
+	pdo_pool_binding_release_query_stmt(binding);
 
-	/* Connection still held — return it to pool (rolls back uncommitted transactions) */
-	if (binding->conn != NULL) {
-		binding->conn->pool_slot_refcount = 0;
-
+	/* Release conn only when no stmt still references it; stmts' destructors
+	 * release it themselves otherwise (last stmt to free does it). */
+	if (binding->conn != NULL && binding->conn->pool_slot_refcount == 0) {
 		zval conn_zval;
 		ZVAL_PTR(&conn_zval, binding->conn);
 		ZEND_ASYNC_POOL_RELEASE(binding->dbh->pool, &conn_zval);
@@ -446,6 +501,8 @@ void pdo_pool_destroy(pdo_dbh_t *dbh)
 	if (dbh->pool_bindings) {
 		pdo_pool_binding_t *binding;
 		ZEND_HASH_FOREACH_PTR(dbh->pool_bindings, binding) {
+			pdo_pool_binding_release_query_stmt(binding);
+
 			/* Release active connection back to pool */
 			if (binding->conn != NULL && dbh->pool != NULL) {
 				binding->conn->pool_slot_refcount = 0;
@@ -528,25 +585,25 @@ pdo_dbh_t *pdo_pool_acquire_conn(pdo_dbh_t *dbh)
 				return binding->conn;
 			}
 
-			/* Connection is broken (cancelled I/O, server gone, etc.)
-			 * Release query_stmt FIRST — it may reference this conn via pooled_conn.
-			 * Then release conn — pool's before_release will destroy it. */
-			pdo_pool_reset_error(dbh);
-			binding->conn->pool_slot_refcount = 0;
-			zval conn_zval;
-			ZVAL_PTR(&conn_zval, binding->conn);
-			ZEND_ASYNC_POOL_RELEASE(dbh->pool, &conn_zval);
+			/* Broken: detach. If stmts still hold conn via pooled_conn,
+			 * last stmt's free will release it; otherwise release now. */
+			pdo_pool_binding_release_query_stmt(binding);
+			pdo_dbh_t *old_conn = binding->conn;
 			binding->conn = NULL;
+			if (old_conn->pool_slot_refcount == 0) {
+				zval cz;
+				ZVAL_PTR(&cz, old_conn);
+				ZEND_ASYNC_POOL_RELEASE(dbh->pool, &cz);
+			}
 		}
 
-		/* Connection was released earlier, acquire a new one into the same binding.
-		 * Reset error state on the template so the new coroutine starts clean. */
+		pdo_pool_binding_release_query_stmt(binding);
+		memcpy(dbh->error_code, PDO_ERR_NONE, sizeof(pdo_error_type));
 		zval resource;
 		if (UNEXPECTED(!ZEND_ASYNC_POOL_ACQUIRE(dbh->pool, &resource, 0))) {
 			return NULL;
 		}
 		binding->conn = Z_PTR(resource);
-		pdo_pool_reset_error(dbh);
 		return binding->conn;
 	}
 
@@ -572,7 +629,7 @@ pdo_dbh_t *pdo_pool_acquire_conn(pdo_dbh_t *dbh)
 		binding->has_coro_callback = true;
 	}
 
-	pdo_pool_reset_error(dbh);
+	memcpy(dbh->error_code, PDO_ERR_NONE, sizeof(pdo_error_type));
 	return binding->conn;
 }
 

--- a/ext/pdo/pdo_pool.c
+++ b/ext/pdo/pdo_pool.c
@@ -71,10 +71,12 @@ static pdo_pool_binding_t *pdo_pool_current_binding(pdo_dbh_t *dbh)
 	if (dbh->pool == NULL || dbh->pool_bindings == NULL) {
 		return NULL;
 	}
+
 	zend_coroutine_t *coro = ZEND_ASYNC_CURRENT_COROUTINE;
 	if (coro == NULL) {
 		return NULL;
 	}
+
 	return zend_hash_index_find_ptr(dbh->pool_bindings, pdo_pool_coro_key(coro));
 }
 
@@ -83,7 +85,9 @@ pdo_stmt_t *pdo_dbh_get_last_failed_query_stmt(pdo_dbh_t *dbh)
 	if (dbh->pool == NULL) {
 		return dbh->last_failed_query_stmt;
 	}
+
 	pdo_pool_binding_t *binding = pdo_pool_current_binding(dbh);
+
 	return binding ? binding->last_failed_query_stmt : NULL;
 }
 
@@ -93,19 +97,24 @@ void pdo_dbh_set_last_failed_query_stmt(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zend_o
 		if (dbh->last_failed_query_stmt_obj != NULL) {
 			OBJ_RELEASE(dbh->last_failed_query_stmt_obj);
 		}
+
 		dbh->last_failed_query_stmt = stmt;
 		dbh->last_failed_query_stmt_obj = obj;
+
 		return;
 	}
+
 	/* No binding (shouldn't happen — caller just acquired conn): silently
 	 * skip the stash. We do NOT OBJ_RELEASE(obj) — caller still uses stmt. */
 	pdo_pool_binding_t *binding = pdo_pool_current_binding(dbh);
 	if (UNEXPECTED(binding == NULL)) {
 		return;
 	}
+
 	if (binding->last_failed_query_stmt_obj != NULL) {
 		OBJ_RELEASE(binding->last_failed_query_stmt_obj);
 	}
+
 	binding->last_failed_query_stmt = stmt;
 	binding->last_failed_query_stmt_obj = obj;
 }
@@ -118,8 +127,10 @@ void pdo_dbh_release_last_failed_query_stmt(pdo_dbh_t *dbh)
 			dbh->last_failed_query_stmt_obj = NULL;
 			dbh->last_failed_query_stmt = NULL;
 		}
+
 		return;
 	}
+
 	pdo_pool_binding_t *binding = pdo_pool_current_binding(dbh);
 	if (binding != NULL) {
 		pdo_pool_binding_release_query_stmt(binding);
@@ -588,8 +599,10 @@ pdo_dbh_t *pdo_pool_acquire_conn(pdo_dbh_t *dbh)
 			/* Broken: detach. If stmts still hold conn via pooled_conn,
 			 * last stmt's free will release it; otherwise release now. */
 			pdo_pool_binding_release_query_stmt(binding);
+
 			pdo_dbh_t *old_conn = binding->conn;
 			binding->conn = NULL;
+
 			if (old_conn->pool_slot_refcount == 0) {
 				zval cz;
 				ZVAL_PTR(&cz, old_conn);
@@ -599,10 +612,12 @@ pdo_dbh_t *pdo_pool_acquire_conn(pdo_dbh_t *dbh)
 
 		pdo_pool_binding_release_query_stmt(binding);
 		memcpy(dbh->error_code, PDO_ERR_NONE, sizeof(pdo_error_type));
+
 		zval resource;
 		if (UNEXPECTED(!ZEND_ASYNC_POOL_ACQUIRE(dbh->pool, &resource, 0))) {
 			return NULL;
 		}
+
 		binding->conn = Z_PTR(resource);
 		return binding->conn;
 	}

--- a/ext/pdo/pdo_pool.c
+++ b/ext/pdo/pdo_pool.c
@@ -526,10 +526,12 @@ void pdo_pool_destroy(pdo_dbh_t *dbh)
 		ZEND_HASH_FOREACH_PTR(dbh->pool_bindings, binding) {
 			pdo_pool_binding_release_query_stmt(binding);
 
-			/* Release active connection back to pool */
-			if (binding->conn != NULL && dbh->pool != NULL) {
-				binding->conn->pool_slot_refcount = 0;
-
+			/* By invariant, at dbh destruction all stmts are gone (they
+			 * held a ref to dbh), so pool_slot_refcount == 0 on every conn.
+			 * Release only when that holds — otherwise leak (visible) is
+			 * safer than force-release (UAF). */
+			if (binding->conn != NULL && dbh->pool != NULL
+				&& binding->conn->pool_slot_refcount == 0) {
 				zval conn_zval;
 				ZVAL_PTR(&conn_zval, binding->conn);
 				ZEND_ASYNC_POOL_RELEASE(dbh->pool, &conn_zval);

--- a/ext/pdo/pdo_pool.c
+++ b/ext/pdo/pdo_pool.c
@@ -55,6 +55,8 @@ typedef struct {
 
 	pdo_stmt_t  *last_failed_query_stmt;
 	zend_object *last_failed_query_stmt_obj;
+
+	pdo_error_type error_code;
 } pdo_pool_binding_t;
 
 static void pdo_pool_binding_release_query_stmt(pdo_pool_binding_t *binding)
@@ -135,6 +137,16 @@ void pdo_dbh_release_last_failed_query_stmt(pdo_dbh_t *dbh)
 	if (binding != NULL) {
 		pdo_pool_binding_release_query_stmt(binding);
 	}
+}
+
+pdo_error_type *pdo_dbh_error_code(pdo_dbh_t *dbh)
+{
+	pdo_pool_binding_t *binding = pdo_pool_current_binding(dbh);
+	if (binding != NULL) {
+		return &binding->error_code;
+	}
+
+	return &dbh->error_code;
 }
 
 /*
@@ -611,7 +623,7 @@ pdo_dbh_t *pdo_pool_acquire_conn(pdo_dbh_t *dbh)
 		}
 
 		pdo_pool_binding_release_query_stmt(binding);
-		memcpy(dbh->error_code, PDO_ERR_NONE, sizeof(pdo_error_type));
+		memcpy(binding->error_code, PDO_ERR_NONE, sizeof(pdo_error_type));
 
 		zval resource;
 		if (UNEXPECTED(!ZEND_ASYNC_POOL_ACQUIRE(dbh->pool, &resource, 0))) {
@@ -635,6 +647,7 @@ pdo_dbh_t *pdo_pool_acquire_conn(pdo_dbh_t *dbh)
 	binding->dbh = dbh;
 	binding->conn = Z_PTR(resource);
 	binding->coro_key = coro_key;
+	memcpy(binding->error_code, PDO_ERR_NONE, sizeof(pdo_error_type));
 
 	zend_hash_index_add_new_ptr(dbh->pool_bindings, coro_key, binding);
 
@@ -644,7 +657,6 @@ pdo_dbh_t *pdo_pool_acquire_conn(pdo_dbh_t *dbh)
 		binding->has_coro_callback = true;
 	}
 
-	memcpy(dbh->error_code, PDO_ERR_NONE, sizeof(pdo_error_type));
 	return binding->conn;
 }
 

--- a/ext/pdo/pdo_pool.h
+++ b/ext/pdo/pdo_pool.h
@@ -60,6 +60,10 @@ pdo_dbh_t *pdo_pool_peek_conn(pdo_dbh_t *dbh);
  */
 void pdo_pool_maybe_release(pdo_dbh_t *dbh);
 
+pdo_stmt_t *pdo_dbh_get_last_failed_query_stmt(pdo_dbh_t *dbh);
+void pdo_dbh_set_last_failed_query_stmt(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zend_object *obj);
+void pdo_dbh_release_last_failed_query_stmt(pdo_dbh_t *dbh);
+
 /*
  * Per-physical-connection prepared-statement cache (opt-in).
  *

--- a/ext/pdo/pdo_pool.h
+++ b/ext/pdo/pdo_pool.h
@@ -64,6 +64,11 @@ pdo_stmt_t *pdo_dbh_get_last_failed_query_stmt(pdo_dbh_t *dbh);
 void pdo_dbh_set_last_failed_query_stmt(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zend_object *obj);
 void pdo_dbh_release_last_failed_query_stmt(pdo_dbh_t *dbh);
 
+/* Pool-aware accessor for dbh->error_code (SQLSTATE). In pool mode returns
+ * the current coroutine's binding-local storage; falls back to template
+ * when there is no binding (top-level / non-pool). */
+pdo_error_type *pdo_dbh_error_code(pdo_dbh_t *dbh);
+
 /*
  * Per-physical-connection prepared-statement cache (opt-in).
  *
@@ -121,10 +126,11 @@ PDO_API void pdo_pool_stmt_cache_entry_free(pdo_pool_stmt_cache_entry_t *entry);
 PDO_API uint32_t pdo_pool_stmt_cache_size(const pdo_pool_stmt_cache_t *cache);
 PDO_API uint32_t pdo_pool_stmt_cache_capacity(const pdo_pool_stmt_cache_t *cache);
 
-/* Sync error_code from pooled conn to template dbh */
+/* Sync error_code from pooled conn into the current coroutine's binding
+ * storage (per-binding in pool mode, template otherwise). */
 static inline void pdo_pool_sync_error(pdo_dbh_t *dbh, const pdo_dbh_t *conn) {
 	if (conn != dbh) {
-		memcpy(dbh->error_code, conn->error_code, sizeof(pdo_error_type));
+		memcpy(*pdo_dbh_error_code(dbh), conn->error_code, sizeof(pdo_error_type));
 	}
 }
 

--- a/ext/pdo/pdo_stmt.c
+++ b/ext/pdo/pdo_stmt.c
@@ -2035,10 +2035,20 @@ PDO_API void php_pdo_free_statement(pdo_stmt_t *stmt)
 		stmt->methods->dtor(stmt);
 	}
 
-	/* Release pooled connection back to pool */
 	if (stmt->pooled_conn != NULL) {
-		stmt->pooled_conn->pool_slot_refcount--;
-		pdo_pool_maybe_release(stmt->dbh);
+		pdo_dbh_t *pconn = stmt->pooled_conn;
+		pconn->pool_slot_refcount--;
+		if (pconn->pool_slot_refcount == 0) {
+			if (pdo_pool_peek_conn(stmt->dbh) == pconn) {
+				pdo_pool_maybe_release(stmt->dbh);
+			} else {
+				/* Orphaned conn (binding switched away or coroutine ended) —
+				 * release directly; pool destroys it if broken. */
+				zval conn_zval;
+				ZVAL_PTR(&conn_zval, pconn);
+				ZEND_ASYNC_POOL_RELEASE(stmt->dbh->pool, &conn_zval);
+			}
+		}
 		stmt->pooled_conn = NULL;
 	}
 

--- a/ext/pdo/pdo_stmt.c
+++ b/ext/pdo/pdo_stmt.c
@@ -2038,6 +2038,7 @@ PDO_API void php_pdo_free_statement(pdo_stmt_t *stmt)
 	if (stmt->pooled_conn != NULL) {
 		pdo_dbh_t *pconn = stmt->pooled_conn;
 		pconn->pool_slot_refcount--;
+
 		if (pconn->pool_slot_refcount == 0) {
 			if (pdo_pool_peek_conn(stmt->dbh) == pconn) {
 				pdo_pool_maybe_release(stmt->dbh);
@@ -2049,6 +2050,7 @@ PDO_API void php_pdo_free_statement(pdo_stmt_t *stmt)
 				ZEND_ASYNC_POOL_RELEASE(stmt->dbh->pool, &conn_zval);
 			}
 		}
+
 		stmt->pooled_conn = NULL;
 	}
 

--- a/ext/pdo/php_pdo_driver.h
+++ b/ext/pdo/php_pdo_driver.h
@@ -526,12 +526,8 @@ struct _pdo_dbh_t {
 
 	zval def_stmt_ctor_args;
 
-	/* when calling PDO::query(), we need to keep the error
-	 * context from the statement around until we next clear it.
-	 * This will allow us to report the correct error message
-	 * when PDO::query() fails */
-	pdo_stmt_t *query_stmt;
-	zend_object *query_stmt_obj;
+	pdo_stmt_t *last_failed_query_stmt;
+	zend_object *last_failed_query_stmt_obj;
 
 	/* Connection pool (requires async extension) */
 	zend_async_pool_t *pool;		/* internal pool, NULL if pooling disabled */

--- a/ext/pdo/php_pdo_error.h
+++ b/ext/pdo/php_pdo_error.h
@@ -16,17 +16,14 @@
 #define PHP_PDO_ERROR_H
 
 #include "php_pdo_driver.h"
+#include "pdo_pool.h"
 
 PDO_API void pdo_handle_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt);
 
 #define PDO_DBH_CLEAR_ERR()             do { \
 	ZEND_ASSERT(sizeof(dbh->error_code) == sizeof(PDO_ERR_NONE)); \
 	memcpy(dbh->error_code, PDO_ERR_NONE, sizeof(PDO_ERR_NONE)); \
-	if (dbh->query_stmt) { \
-		dbh->query_stmt = NULL; \
-		OBJ_RELEASE(dbh->query_stmt_obj); \
-		dbh->query_stmt_obj = NULL; \
-	} \
+	pdo_dbh_release_last_failed_query_stmt(dbh); \
 } while (0)
 #define PDO_STMT_CLEAR_ERR() do { \
 	ZEND_ASSERT(sizeof(stmt->error_code) == sizeof(PDO_ERR_NONE)); \

--- a/ext/pdo/php_pdo_error.h
+++ b/ext/pdo/php_pdo_error.h
@@ -22,14 +22,14 @@ PDO_API void pdo_handle_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt);
 
 #define PDO_DBH_CLEAR_ERR()             do { \
 	ZEND_ASSERT(sizeof(dbh->error_code) == sizeof(PDO_ERR_NONE)); \
-	memcpy(dbh->error_code, PDO_ERR_NONE, sizeof(PDO_ERR_NONE)); \
+	memcpy(*pdo_dbh_error_code(dbh), PDO_ERR_NONE, sizeof(PDO_ERR_NONE)); \
 	pdo_dbh_release_last_failed_query_stmt(dbh); \
 } while (0)
 #define PDO_STMT_CLEAR_ERR() do { \
 	ZEND_ASSERT(sizeof(stmt->error_code) == sizeof(PDO_ERR_NONE)); \
 	memcpy(stmt->error_code, PDO_ERR_NONE, sizeof(PDO_ERR_NONE)); \
 } while (0)
-#define PDO_HANDLE_DBH_ERR()    if (strcmp(dbh->error_code, PDO_ERR_NONE) != 0) { pdo_handle_error(dbh, NULL); }
+#define PDO_HANDLE_DBH_ERR()    if (strcmp(*pdo_dbh_error_code(dbh), PDO_ERR_NONE) != 0) { pdo_handle_error(dbh, NULL); }
 #define PDO_HANDLE_STMT_ERR_EX(cleanup_instruction)   if (strcmp(stmt->error_code, PDO_ERR_NONE) != 0) {  cleanup_instruction pdo_handle_error(stmt->dbh, stmt); }
 #define PDO_HANDLE_STMT_ERR() PDO_HANDLE_STMT_ERR_EX(;)
 


### PR DESCRIPTION
Two real bugs found by the new `ext/async` chaos suite for true-async/php-async#136 and the cleanup that landed with them.

## Bugs fixed

**`ext/curl/curl_async.c` — async write callback dropped a chunked response body**

Caught by `fuzzy-tests/curl/http_chaos.feature` (`chunked` rows). Symptom: `CURLE_WRITE_ERROR` after only the first chunk; libcurl reported `passed 272 returned 17`. Root cause: the async write path uses `CURL_WRITEFUNC_PAUSE`/unpause and the re-call assumed libcurl re-delivers exactly the slice that was paused on. It does not — on unpause libcurl re-delivers the whole paused window AND coalesces freshly decoded data into it. Fixed in `curl_async_write_user` with a `consumed_offset` that walks the (possibly grown) re-call window; the full length is reported to libcurl only once the PHP callback has accepted every byte, otherwise the remainder is fed through another callback slice. `state->aborted` flag preserves short-return / exception semantics verbatim.

**`ext/pdo/pdo_pool.c` — UAF when a coroutine is cancelled mid-transaction**

Caught by `fuzzy-tests/db/concurrent.feature` (`a transaction cancelled while a sibling keeps working`, ms=2). Symptom: SEGV in `php_pdo_free_statement` (`pdo_stmt.c:2035`) on the call through `stmt->methods`. Root cause was a cluster of layer violations on the shared template `pdo_dbh_t` in pool mode:

- `dbh->query_stmt[_obj]` (the last-failed-`PDO::query()` stmt stash) lived on the template — every coroutine sharing the `$pdo` wrote / read / cleared it from its own paths, racing on a shared slot.
- Three sites force-set `pool_slot_refcount = 0` before releasing a broken/orphan conn — pretending no stmt still referenced it when in fact the cancelling coroutine's stmts did. The pool then destroyed the conn (`conn_broken=true` → `before_release` returns false), dangling `stmt->pooled_conn` pointers.

## Refactor

- `dbh->query_stmt[_obj]` renamed to `last_failed_query_stmt[_obj]` (the field's actual role).
- Pool mode: moved the stash from the template to a per-coroutine `pdo_pool_binding_t`. Cleared on conn switch (fresh conn → fresh session) and on coroutine finish.
- Same recipe for `dbh->error_code` — also template-shared in pool mode, racy on the 6-byte memcpy. Moved to per-binding storage.
- New API `pdo_dbh_{get,set,release}_last_failed_query_stmt` + `pdo_dbh_error_code` dispatch template vs binding. All `PDO_DBH_CLEAR_ERR`, `PDO_HANDLE_DBH_ERR`, `pdo_pool_sync_error`, `PDO::query()` failed path, `errorCode()`, `errorInfo()`, `pdo_raise_impl_error`, `pdo_handle_error`, `dbh_free` go through the dispatch.
- All three `pool_slot_refcount = 0` force-zero sites removed (`pdo_pool_binding_on_coroutine_finish`, `pdo_pool_acquire_conn` broken branch, `pdo_pool_destroy`). Each now releases the conn only when `pool_slot_refcount == 0`; otherwise the last stmt's `php_pdo_free_statement` does it.
- `php_pdo_free_statement`: when `pool_slot_refcount` drops to 0 and the conn is no longer the current binding's (detached as broken, or coroutine ended), release the conn directly. The pool's `before_release` sees `conn_broken` and destroys it.

Invariant: a conn is returned to the pool only when `pool_slot_refcount` reaches 0 — no stmt still references it. The pool itself decides recycle vs destroy (`conn_broken` / `in_txn` checks in `pdo_pool_before_release`, untouched).

## Verification

- Full 649-test fuzzy suite passes on the default scheduler.
- Same suite passes under `TRUE_ASYNC_SCHED=random:N` for seeds 1, 7, 42, 1009, 31337.
- Debug-build leak detector is clean in the previously-crashing scenarios.

## Order with php-async

`ext/async` CI clones `php-src@true-async-stable`. The chaos suite in true-async/php-async#136 needs this PR merged first — otherwise the chaos `.phpt` segfault in CI.