### PR TITLE
#146 flock: move task data off the caller stack (UAF on cancel)

### DIFF
--- a/main/streams/plain_wrapper.c
+++ b/main/streams/plain_wrapper.c
@@ -1189,8 +1189,20 @@ static int php_stdiop_set_option(php_stream *stream, int option, int value, void
 					return -1;
 				}
 
-				php_stdiop_flock_task_data_t flock_data = { .fd = fd, .operation = value };
-				zend_async_task_t *task = ZEND_ASYNC_NEW_TASK(php_stdiop_flock_task_run, &flock_data);
+				/* Inline-tail so flock_data outlives caller on cancel —
+				 * worker keeps writing after AsyncCancellation unwinds the frame. */
+				zend_async_task_t *task = ZEND_ASYNC_NEW_TASK_EX(
+					php_stdiop_flock_task_run, NULL,
+					sizeof(php_stdiop_flock_task_data_t));
+				if (UNEXPECTED(task == NULL)) {
+					return -1;
+				}
+				php_stdiop_flock_task_data_t *flock_data =
+					(php_stdiop_flock_task_data_t *)
+						((char *)task + task->base.extra_offset);
+				flock_data->fd = fd;
+				flock_data->operation = value;
+				task->data = flock_data;
 
 				zend_coroutine_t *const coroutine = ZEND_ASYNC_CURRENT_COROUTINE;
 				ZEND_ASYNC_WAKER_NEW(coroutine);
@@ -1211,12 +1223,12 @@ static int php_stdiop_set_option(php_stream *stream, int option, int value, void
 					return -1;
 				}
 
-				if (flock_data.result == 0) {
+				if (flock_data->result == 0) {
 					data->lock_flag = value;
 					return 0;
 				}
 
-				errno = flock_data.error_code;
+				errno = flock_data->error_code;
 				return -1;
 			}
 


### PR DESCRIPTION
## Bug

\`php_stdiop_flock_task_data_t\` was on the caller's stack while the libuv worker thread held a pointer to it. On AsyncCancellation mid-suspend the caller frame unwound and the still-running worker wrote into a freed stack slot. ASAN traced it precisely:

\`\`\`
==…==ERROR: AddressSanitizer: stack-use-after-return
WRITE of size 4 in php_stdiop_flock_task_run main/streams/plain_wrapper.c:1097 (thread T4 = libuv worker)
\`\`\`

Reproducible with ~20 lines (see #146).

## Fix

Allocate the task with **inline-tail storage** via the existing \`ZEND_ASYNC_NEW_TASK_EX(run, data, extra_size)\` API — \`flock_data\` lives at the tail of the task struct itself. The task is refcounted and survives caller unwind; \`libuv_task_dispose\`'s \`pefree(task)\` frees the inline data as part of normal cleanup.

No ABI changes, no new helpers — uses existing public task API.

## Audit

Grepped for other \`ZEND_ASYNC_NEW_TASK*\` callsites in core: only this one. No similar stack-data-into-async-worker patterns elsewhere.

## Test

- \`fuzzy-tests/io/flock_chaos.feature\` — 4 cancel-mid-flock scenarios (regression backstop) green on fifo + 4 random seeds + ASAN-ZTS
- \`ext/async/tests/io/\` full regression (84 phpt) — no failures
- Feature file companion uncomment lives in the umbrella chaos PR (#147)

Fixes #146