### PR TITLE
#145 ext/curl: route cancelled curl_multi_select through finally (UAF)

### DIFF
--- a/ext/curl/curl_async.c
+++ b/ext/curl/curl_async.c
@@ -1174,7 +1174,13 @@ CURLMcode curl_async_select(php_curlm * curl_m, int timeout_ms, int* numfds)
 
 	// Suspend coroutine until events are ready
 	if (!ZEND_ASYNC_SUSPEND()) {
-		return CURLM_INTERNAL_ERROR;
+		/* MUST go through finally to call waker_clean: otherwise C's
+		 * callback stays subscribed to async_event, and a later
+		 * multi_socket_cb(CURL_POLL_REMOVE) → CALLBACKS_NOTIFY fires
+		 * resume() on the still-running coroutine → stale queue entry
+		 * → UAF on the next dequeue. See true-async/php-async#145. */
+		result = CURLM_INTERNAL_ERROR;
+		goto finally;
 	}
 
 	// Clear timeout exception if it occurred


### PR DESCRIPTION
## Summary

Fixes true-async/php-async#145 — heap-use-after-free when AsyncCancellation interrupts `curl_multi_select()`.

## Root cause

`ext/curl/curl_async.c:1176-1178` early-returned `CURLM_INTERNAL_ERROR` on SUSPEND failure, skipping the `finally:` label that calls `zend_async_waker_clean()`. On cancel-mid-select the coroutine's resolve callback stayed subscribed to the multi event. The user's PHP `finally` then drove `curl_multi_close()` → libcurl → `multi_socket_cb(CURL_POLL_REMOVE)` → `CALLBACKS_NOTIFY` on the multi event → `async_coroutine_resume` re-pushed the still-running coroutine into the scheduler runqueue. The runtime warned _"Attempt to finalize a coroutine that is still in the queue"_; the next dequeue dereferenced the freed fcall.

## Fix

Route SUSPEND-failure path through `finally:` so `waker_clean()` unsubscribes before the user's finally can drive libcurl into NOTIFY.

## Test plan

- [x] `r145.php` (50-line repro from the issue): PASS under ASAN-ZTS, prints `OK`, no `zend_mm_panic`, no "still in the queue" warning.
- [x] `ext/async/tests/curl/069-multi_select_cancel_uaf.phpt` (in ext/async PR): PASS.
- [x] ASAN-ZTS sweep of `ext/async/tests/curl` + `ext/async/tests/io`: 150/153 PASS, 0 FAIL, 2 skipped (pre-existing).