### PR TITLE
Zend/async: ThreadPool reload() ABI — v0.22 (true-async/server#93)

### DIFF
--- a/Zend/zend_async_API.h
+++ b/Zend/zend_async_API.h
@@ -1984,7 +1984,10 @@ typedef zend_async_event_t *(*zend_thread_pool_submit_internal_t)(
  * (workers leave the loop when receive() returns false), so reloaded code takes
  * effect without dropping the pool. Replacements are spawned as old workers
  * drain — ~N workers throughout, no 2N spike. Runs on the calling coroutine
- * (it awaits the old cohort draining). */
+ * (it awaits the old cohort draining) and throws if called outside one.
+ * Overlapping calls serialize and coalesce: callers queued behind an active
+ * rotation are all satisfied by the single follow-up rotation that starts
+ * after their entry. */
 typedef void (*zend_thread_pool_reload_t)(zend_async_thread_pool_t *pool);
 /**
  * zend_async_thread_pool_t — base structure for a thread pool.

--- a/Zend/zend_async_API.h
+++ b/Zend/zend_async_API.h
@@ -21,9 +21,9 @@
 #include "zend_globals.h"
 #include "zend_stream.h"
 
-#define ZEND_ASYNC_API "TrueAsync ABI v0.21.0"
+#define ZEND_ASYNC_API "TrueAsync ABI v0.22.0"
 #define ZEND_ASYNC_API_VERSION_MAJOR 0
-#define ZEND_ASYNC_API_VERSION_MINOR 21
+#define ZEND_ASYNC_API_VERSION_MINOR 22
 #define ZEND_ASYNC_API_VERSION_PATCH 0
 
 #define ZEND_ASYNC_API_VERSION_NUMBER \
@@ -1978,6 +1978,19 @@ typedef zend_async_event_t *(*zend_thread_pool_submit_internal_t)(
 	zend_async_thread_pool_t *pool,
 	zend_thread_pool_internal_handler_t handler,
 	void *ctx);
+
+/* Replace the worker thread in slot `idx` with a fresh one (clean CG/EG →
+ * reloaded code). The old thread self-terminates once its current task ends and
+ * its exit was requested; the caller drives that ordering. Returns false on a
+ * bad index or a closed pool. */
+typedef bool (*zend_thread_pool_respawn_worker_t)(
+	zend_async_thread_pool_t *pool, int32_t idx);
+
+/* Ask the worker in slot `idx` to leave its receive loop after its current task
+ * completes (cooperative — the running task must return on its own). Wakes the
+ * worker's control channel so a task awaiting it can self-stop. */
+typedef bool (*zend_thread_pool_request_worker_exit_t)(
+	zend_async_thread_pool_t *pool, int32_t idx);
 /**
  * zend_async_thread_pool_t — base structure for a thread pool.
  * Manages a fixed set of worker threads with atomic counters
@@ -2008,6 +2021,11 @@ struct _zend_async_thread_pool_s {
 	zend_thread_pool_close_t close;
 	zend_thread_pool_dispose_t dispose;
 	zend_thread_pool_submit_internal_t submit_internal;
+
+	/* Rolling worker replacement for in-place code reload (blue-green). NULL on
+	 * pools created by a runtime older than ABI 0.22 — gate on the API version. */
+	zend_thread_pool_respawn_worker_t respawn_worker;
+	zend_thread_pool_request_worker_exit_t request_worker_exit;
 };
 
 /* Thread pool refcount helpers */

--- a/Zend/zend_async_API.h
+++ b/Zend/zend_async_API.h
@@ -1979,18 +1979,13 @@ typedef zend_async_event_t *(*zend_thread_pool_submit_internal_t)(
 	zend_thread_pool_internal_handler_t handler,
 	void *ctx);
 
-/* Replace the worker thread in slot `idx` with a fresh one (clean CG/EG →
- * reloaded code). The old thread self-terminates once its current task ends and
- * its exit was requested; the caller drives that ordering. Returns false on a
- * bad index or a closed pool. */
-typedef bool (*zend_thread_pool_respawn_worker_t)(
-	zend_async_thread_pool_t *pool, int32_t idx);
-
-/* Ask the worker in slot `idx` to leave its receive loop after its current task
- * completes (cooperative — the running task must return on its own). Wakes the
- * worker's control channel so a task awaiting it can self-stop. */
-typedef bool (*zend_thread_pool_request_worker_exit_t)(
-	zend_async_thread_pool_t *pool, int32_t idx);
+/* Reload the pool's workers in place, rolling (blue-green): fresh workers are
+ * started on a NEW task channel and the old cohort is retired by closing theirs
+ * (workers leave the loop when receive() returns false), so reloaded code takes
+ * effect without dropping the pool. Replacements are spawned as old workers
+ * drain — ~N workers throughout, no 2N spike. Runs on the calling coroutine
+ * (it awaits the old cohort draining). */
+typedef void (*zend_thread_pool_reload_t)(zend_async_thread_pool_t *pool);
 /**
  * zend_async_thread_pool_t — base structure for a thread pool.
  * Manages a fixed set of worker threads with atomic counters
@@ -2022,10 +2017,9 @@ struct _zend_async_thread_pool_s {
 	zend_thread_pool_dispose_t dispose;
 	zend_thread_pool_submit_internal_t submit_internal;
 
-	/* Rolling worker replacement for in-place code reload (blue-green). NULL on
-	 * pools created by a runtime older than ABI 0.22 — gate on the API version. */
-	zend_thread_pool_respawn_worker_t respawn_worker;
-	zend_thread_pool_request_worker_exit_t request_worker_exit;
+	/* In-place rolling worker reload (blue-green). NULL on pools created by a
+	 * runtime older than ABI 0.22 — gate on the API version. */
+	zend_thread_pool_reload_t reload;
 };
 
 /* Thread pool refcount helpers */


### PR DESCRIPTION
Adds a single `reload` method to the `zend_async_thread_pool_t` vtable (appended, additive) and bumps the ABI to **v0.22.0**.

Semantics (implemented in true-async/php-async#169): rolling blue-green worker reload — fresh workers on a new task channel, old cohort drains and exits, replacements spawn 1:1 (~N workers throughout). Runs on the calling coroutine and throws outside one; overlapping calls serialize and coalesce. `reload` is NULL on pools created by an older runtime — gate on the API version.

Supersedes the rejected `respawn_worker`/`request_worker_exit` pair (adba92a).