### PR TITLE
Add the Async Scheduler Hook API: a thin, policy-free concurrency core

### DIFF
--- a/Zend/tests/async/fiber_lowlevel_null.phpt
+++ b/Zend/tests/async/fiber_lowlevel_null.phpt
@@ -1,0 +1,34 @@
+--TEST--
+intercept_fiber returning null keeps the fiber on the low-level path
+--FILE--
+<?php
+Async\SchedulerHook::register('test', [
+    Async\SchedulerHook::INTERCEPT_FIBER => function (Fiber $fiber): ?object {
+        echo "intercept: null\n";
+        return null;
+    },
+    Async\SchedulerHook::SUSPEND => function (bool $fromMain, bool $isBailout): bool {
+        // Never called for the low-level fiber itself; the engine invokes it
+        // for the after-main handover (script end, then after destructors).
+        echo "suspend(fromMain: ", var_export($fromMain, true), ")\n";
+        return true;
+    },
+]);
+
+// A low-level fiber behaves exactly as classic Fiber even with a scheduler.
+$fiber = new Fiber(function (int $x): int {
+    $y = Fiber::suspend($x + 1);
+    return $y * 10;
+});
+
+var_dump($fiber->start(5));
+var_dump($fiber->resume(4));
+var_dump($fiber->getReturn());
+?>
+--EXPECT--
+intercept: null
+int(6)
+NULL
+int(40)
+suspend(fromMain: true)
+suspend(fromMain: true)

--- a/Zend/tests/async/fiber_managed_after_main.phpt
+++ b/Zend/tests/async/fiber_managed_after_main.phpt
@@ -1,0 +1,50 @@
+--TEST--
+After-main handover runs deferred managed coroutines; abandoned ones die cleanly
+--FILE--
+<?php
+$queue = new SplQueue();
+
+Async\SchedulerHook::register('test', [
+    Async\SchedulerHook::INTERCEPT_FIBER => fn (Fiber $fiber): object
+        => new class($fiber) {
+            public function __construct(public readonly Fiber $fiber) {}
+        },
+    Async\SchedulerHook::ENQUEUE => function (object $coroutine) use ($queue): bool {
+        $queue->enqueue($coroutine);
+        return true;
+    },
+    Async\SchedulerHook::SUSPEND => function (bool $fromMain, bool $isBailout) use ($queue): bool {
+        // This scheduler defers everything: nothing runs until after main.
+        if (!$fromMain) {
+            return true;
+        }
+
+        while (!$queue->isEmpty()) {
+            $fiber = $queue->dequeue()->fiber;
+            $fiber->isStarted() ? $fiber->resume() : $fiber->start();
+        }
+
+        return true;
+    },
+]);
+
+$fiber = new Fiber(function (): void {
+    echo "ran after main\n";
+    Fiber::suspend();
+    echo "never printed: nobody resumes\n";
+});
+
+// The deferring scheduler does not run the fiber here.
+var_dump($fiber->start());
+var_dump($fiber->isStarted());
+
+echo "end of script\n";
+// After-main handover: the scheduler drains its queue, the fiber runs and
+// suspends. Nobody resumes it, so it is destroyed at shutdown without
+// completing; the second echo never happens.
+?>
+--EXPECT--
+NULL
+bool(false)
+end of script
+ran after main

--- a/Zend/tests/async/fiber_managed_basic.phpt
+++ b/Zend/tests/async/fiber_managed_basic.phpt
@@ -1,0 +1,62 @@
+--TEST--
+A fiber adopted by the scheduler runs through the coroutine path
+--FILE--
+<?php
+$queue = new SplQueue();
+$log = [];
+
+Async\SchedulerHook::register('test', [
+    Async\SchedulerHook::INTERCEPT_FIBER => function (Fiber $fiber) use (&$log): object {
+        $log[] = 'intercept';
+
+        // The scheduler defines the coroutine; here it simply remembers
+        // which fiber the coroutine drives.
+        return new class($fiber) {
+            public function __construct(public readonly Fiber $fiber) {}
+        };
+    },
+    Async\SchedulerHook::ENQUEUE => function (object $coroutine) use ($queue, &$log): bool {
+        $log[] = 'enqueue';
+        $queue->enqueue($coroutine);
+        return true;
+    },
+    Async\SchedulerHook::RESUME => function (object $coroutine, ?Throwable $error) use ($queue, &$log): bool {
+        $log[] = 'resume';
+        $queue->enqueue($coroutine);
+        return true;
+    },
+    Async\SchedulerHook::SUSPEND => function (bool $fromMain, bool $isBailout) use ($queue, &$log): bool {
+        $log[] = 'suspend';
+
+        while (!$queue->isEmpty()) {
+            $fiber = $queue->dequeue()->fiber;
+            $fiber->isStarted() ? $fiber->resume() : $fiber->start();
+
+            if (!$fromMain) {
+                return true;
+            }
+        }
+
+        return true;
+    },
+]);
+
+$fiber = new Fiber(function (int $x): int {
+    $y = Fiber::suspend($x + 1);
+    return $y * 10;
+});
+
+var_dump($fiber->start(5));
+var_dump($fiber->isSuspended());
+var_dump($fiber->resume(4));
+var_dump($fiber->isTerminated());
+var_dump($fiber->getReturn());
+echo implode(',', $log), "\n";
+?>
+--EXPECT--
+int(6)
+bool(true)
+NULL
+bool(true)
+int(40)
+intercept,enqueue,suspend,resume,suspend

--- a/Zend/tests/async/fiber_managed_throw.phpt
+++ b/Zend/tests/async/fiber_managed_throw.phpt
@@ -1,0 +1,52 @@
+--TEST--
+Fiber::throw() on a managed fiber delivers the exception at the suspension point
+--FILE--
+<?php
+$queue = new SplQueue();
+
+Async\SchedulerHook::register('test', [
+    Async\SchedulerHook::INTERCEPT_FIBER => fn (Fiber $fiber): object
+        => new class($fiber) {
+            public function __construct(public readonly Fiber $fiber) {}
+        },
+    Async\SchedulerHook::ENQUEUE => function (object $coroutine) use ($queue): bool {
+        $queue->enqueue($coroutine);
+        return true;
+    },
+    Async\SchedulerHook::RESUME => function (object $coroutine, ?Throwable $error) use ($queue): bool {
+        echo "resume hook error: ", $error === null ? 'none' : get_class($error), "\n";
+        $queue->enqueue($coroutine);
+        return true;
+    },
+    Async\SchedulerHook::SUSPEND => function (bool $fromMain, bool $isBailout) use ($queue): bool {
+        while (!$queue->isEmpty()) {
+            $fiber = $queue->dequeue()->fiber;
+            $fiber->isStarted() ? $fiber->resume() : $fiber->start();
+
+            if (!$fromMain) {
+                return true;
+            }
+        }
+
+        return true;
+    },
+]);
+
+$fiber = new Fiber(function (): string {
+    try {
+        Fiber::suspend('waiting');
+    } catch (RuntimeException $e) {
+        return 'caught: ' . $e->getMessage();
+    }
+
+    return 'not reached';
+});
+
+var_dump($fiber->start());
+$fiber->throw(new RuntimeException('boom'));
+var_dump($fiber->getReturn());
+?>
+--EXPECT--
+string(7) "waiting"
+resume hook error: RuntimeException
+string(12) "caught: boom"

--- a/Zend/tests/async/fiber_managed_uncaught.phpt
+++ b/Zend/tests/async/fiber_managed_uncaught.phpt
@@ -1,0 +1,44 @@
+--TEST--
+An uncaught exception in a managed fiber surfaces at the start()/resume() caller
+--FILE--
+<?php
+$queue = new SplQueue();
+
+Async\SchedulerHook::register('test', [
+    Async\SchedulerHook::INTERCEPT_FIBER => fn (Fiber $fiber): object
+        => new class($fiber) {
+            public function __construct(public readonly Fiber $fiber) {}
+        },
+    Async\SchedulerHook::ENQUEUE => function (object $coroutine) use ($queue): bool {
+        $queue->enqueue($coroutine);
+        return true;
+    },
+    Async\SchedulerHook::SUSPEND => function (bool $fromMain, bool $isBailout) use ($queue): bool {
+        while (!$queue->isEmpty()) {
+            $fiber = $queue->dequeue()->fiber;
+            $fiber->isStarted() ? $fiber->resume() : $fiber->start();
+
+            if (!$fromMain) {
+                return true;
+            }
+        }
+
+        return true;
+    },
+]);
+
+$fiber = new Fiber(function (): void {
+    throw new RuntimeException('escaped');
+});
+
+try {
+    $fiber->start();
+} catch (RuntimeException $e) {
+    echo "caught: ", $e->getMessage(), "\n";
+}
+
+var_dump($fiber->isTerminated());
+?>
+--EXPECT--
+caught: escaped
+bool(true)

--- a/Zend/tests/async/gc_destructors_hook.phpt
+++ b/Zend/tests/async/gc_destructors_hook.phpt
@@ -1,0 +1,81 @@
+--TEST--
+GC destructor phase: the hook brackets the engine run and awaits spawned work
+--FILE--
+<?php
+$queue = new SplQueue();
+
+Async\SchedulerHook::register('test', [
+    Async\SchedulerHook::INTERCEPT_FIBER => fn (Fiber $fiber): object
+        => new class($fiber) {
+            public function __construct(public readonly Fiber $fiber) {}
+        },
+    Async\SchedulerHook::ENQUEUE => function (object $coroutine) use ($queue): bool {
+        $queue->enqueue($coroutine);
+        return true;
+    },
+    Async\SchedulerHook::SUSPEND => function (bool $fromMain, bool $isBailout) use ($queue): bool {
+        // Defer: the queue is drained by the GC hook (and after main).
+        if (!$fromMain) {
+            return true;
+        }
+
+        while (!$queue->isEmpty()) {
+            $fiber = $queue->dequeue()->fiber;
+            $fiber->isStarted() ? $fiber->resume() : $fiber->start();
+        }
+
+        return true;
+    },
+    Async\SchedulerHook::GC_DESTRUCTORS => function (callable $run) use ($queue): bool {
+        echo "hook: before\n";
+
+        $run();     // the engine calls every pending destructor
+
+        // Await everything the destructors spawned (the "scope" logic:
+        // membership is the scheduler's own bookkeeping).
+        while (!$queue->isEmpty()) {
+            $fiber = $queue->dequeue()->fiber;
+            $fiber->isStarted() ? $fiber->resume() : $fiber->start();
+        }
+
+        echo "hook: after\n";
+        return true;
+    },
+]);
+
+class Node
+{
+    public ?Node $other = null;
+
+    public function __destruct()
+    {
+        echo "destructor\n";
+
+        // The destructor spawns concurrent work; the hook must wait for it.
+        $fiber = new Fiber(function (): void {
+            echo "spawned by destructor\n";
+        });
+        $fiber->start();
+    }
+}
+
+// A garbage cycle: collected only by the GC.
+$a = new Node();
+$b = new Node();
+$a->other = $b;
+$b->other = $a;
+unset($a, $b);
+
+$collected = gc_collect_cycles();
+var_dump($collected > 0);
+echo "end\n";
+?>
+--EXPECT--
+hook: before
+destructor
+destructor
+spawned by destructor
+spawned by destructor
+hook: after
+bool(true)
+end

--- a/Zend/tests/async/microtasks_basic.phpt
+++ b/Zend/tests/async/microtasks_basic.phpt
@@ -1,0 +1,43 @@
+--TEST--
+Microtasks: defer() forwards to the scheduler's DEFER hook; the queue is the scheduler's
+--FILE--
+<?php
+$tasks = new SplQueue();
+
+Async\SchedulerHook::register('test', [
+    Async\SchedulerHook::SUSPEND => function (bool $fromMain, bool $isBailout): bool {
+        return true;
+    },
+    Async\SchedulerHook::DEFER => function (callable $task) use ($tasks): bool {
+        // The queue is owned by the scheduler, not by the engine.
+        $tasks->enqueue($task);
+        return true;
+    },
+]);
+
+Async\SchedulerHook::defer(function () use ($tasks): void {
+    echo "task 1\n";
+
+    // Queued while draining: the scheduler decides the semantics; this
+    // one drains everything queued before it finishes (classic microtasks).
+    Async\SchedulerHook::defer(function (): void {
+        echo "task 3 (queued by task 1)\n";
+    });
+});
+
+Async\SchedulerHook::defer(function (): void {
+    echo "task 2\n";
+});
+
+// The scheduler drains its own queue on its tick; simulate one here.
+while (!$tasks->isEmpty()) {
+    ($tasks->dequeue())();
+}
+
+echo "drained\n";
+?>
+--EXPECT--
+task 1
+task 2
+task 3 (queued by task 1)
+drained

--- a/Zend/tests/async/scheduler_context.phpt
+++ b/Zend/tests/async/scheduler_context.phpt
@@ -1,0 +1,64 @@
+--TEST--
+Fiber operations on a bound fiber: direct inside the scheduler, routed outside
+--FILE--
+<?php
+$queue = new SplQueue();
+$log = [];
+
+Async\SchedulerHook::register('test', [
+    Async\SchedulerHook::INTERCEPT_FIBER => fn (Fiber $fiber): object
+        => new class($fiber) {
+            public function __construct(public readonly Fiber $fiber) {}
+        },
+    Async\SchedulerHook::ENQUEUE => function (object $coroutine) use ($queue, &$log): bool {
+        $log[] = 'enqueue';
+        $queue->enqueue($coroutine);
+        return true;
+    },
+    Async\SchedulerHook::RESUME => function (object $coroutine, ?Throwable $error) use ($queue, &$log): bool {
+        $log[] = 'resume-hook';
+        $queue->enqueue($coroutine);
+        return true;
+    },
+    Async\SchedulerHook::SUSPEND => function (bool $fromMain, bool $isBailout) use ($queue, &$log): bool {
+        while (!$queue->isEmpty()) {
+            $fiber = $queue->dequeue()->fiber;
+
+            // Inside a hook this is a DIRECT switch: no hooks re-enter.
+            $fiber->isStarted() ? $fiber->resume() : $fiber->start();
+
+            if (!$fromMain) {
+                return true;
+            }
+        }
+
+        return true;
+    },
+]);
+
+$fiber = new Fiber(function (): string {
+    Fiber::suspend('first');
+    return 'done';
+});
+
+// Application code: operations route through the hooks.
+var_dump($fiber->start());
+var_dump($fiber->resume());
+var_dump($fiber->getReturn());
+
+// The scheduler's direct switches fired no extra hook calls:
+echo implode(',', $log), "\n";
+
+// A finished bound fiber cannot be resumed, same rule as classic fibers.
+try {
+    $fiber->resume();
+} catch (FiberError $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+string(5) "first"
+NULL
+string(4) "done"
+enqueue,resume-hook
+Cannot resume a fiber that is not suspended

--- a/Zend/tests/async/scheduler_hook_constants.phpt
+++ b/Zend/tests/async/scheduler_hook_constants.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Async\SchedulerHook: hook name constants
+--FILE--
+<?php
+var_dump(Async\SchedulerHook::LAUNCH);
+var_dump(Async\SchedulerHook::SHUTDOWN);
+var_dump(Async\SchedulerHook::INTERCEPT_FIBER);
+var_dump(Async\SchedulerHook::ENQUEUE);
+var_dump(Async\SchedulerHook::SUSPEND);
+var_dump(Async\SchedulerHook::RESUME);
+var_dump(Async\SchedulerHook::CANCEL);
+var_dump(Async\SchedulerHook::CONTEXT_FIND);
+var_dump(Async\SchedulerHook::CONTEXT_SET);
+var_dump(Async\SchedulerHook::CONTEXT_UNSET);
+?>
+--EXPECT--
+string(6) "launch"
+string(8) "shutdown"
+string(15) "intercept_fiber"
+string(17) "enqueue_coroutine"
+string(7) "suspend"
+string(6) "resume"
+string(6) "cancel"
+string(12) "context_find"
+string(11) "context_set"
+string(13) "context_unset"

--- a/Zend/tests/async/scheduler_hook_invalid.phpt
+++ b/Zend/tests/async/scheduler_hook_invalid.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Async\SchedulerHook::register rejects a non-callable hook
+--FILE--
+<?php
+try {
+    Async\SchedulerHook::register('test', [
+        Async\SchedulerHook::SUSPEND => 'this_function_does_not_exist',
+    ]);
+} catch (\TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+// A refused registration leaves no active scheduler.
+var_dump(Async\SchedulerHook::getModule());
+?>
+--EXPECTF--
+Async scheduler hook "suspend" must be a valid callable: %s
+NULL

--- a/Zend/tests/async/scheduler_hook_launch.phpt
+++ b/Zend/tests/async/scheduler_hook_launch.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Async\SchedulerHook: launch runs immediately at PHP registration
+--FILE--
+<?php
+$launched = false;
+
+Async\SchedulerHook::register('test', [
+    Async\SchedulerHook::LAUNCH => function () use (&$launched): bool {
+        $launched = true;
+        return true;
+    },
+    Async\SchedulerHook::SUSPEND => function (bool $fromMain, bool $isBailout): bool {
+        return true;
+    },
+]);
+
+// The engine launch point has already passed by the time userland runs,
+// so a PHP scheduler is launched synchronously inside register().
+var_dump($launched);
+?>
+--EXPECT--
+bool(true)

--- a/Zend/tests/async/scheduler_hook_override.phpt
+++ b/Zend/tests/async/scheduler_hook_override.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Async\SchedulerHook::register can be called only once
+--FILE--
+<?php
+$noop = function (bool $fromMain, bool $isBailout): bool { return true; };
+
+// First registration succeeds.
+var_dump(Async\SchedulerHook::register('a', [
+    Async\SchedulerHook::SUSPEND => $noop,
+]));
+
+// A second registration throws: a scheduler is registered once per process.
+try {
+    Async\SchedulerHook::register('b', [
+        Async\SchedulerHook::SUSPEND => $noop,
+    ]);
+} catch (\Error $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+bool(true)
+A scheduler is already registered

--- a/Zend/tests/async/scheduler_hook_register.phpt
+++ b/Zend/tests/async/scheduler_hook_register.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Async\SchedulerHook::register activates and getModule() reports the driver
+--FILE--
+<?php
+var_dump(Async\SchedulerHook::getModule());
+
+$ok = Async\SchedulerHook::register('my-driver', [
+    Async\SchedulerHook::SUSPEND => function (bool $fromMain, bool $isBailout): bool {
+        return true;
+    },
+]);
+
+var_dump($ok);
+var_dump(Async\SchedulerHook::getModule());
+?>
+--EXPECT--
+NULL
+bool(true)
+string(9) "my-driver"

--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -24,6 +24,7 @@
 #include "zend_API.h"
 #include "zend_exceptions.h"
 #include "zend_builtin_functions.h"
+#include "zend_scheduler_hook.h"
 #include "zend_ini.h"
 #include "zend_vm.h"
 #include "zend_dtrace.h"
@@ -1060,6 +1061,7 @@ void zend_startup(zend_utility_functions *utility_functions) /* {{{ */
 	zend_interned_strings_init();
 	zend_object_handlers_startup();
 	zend_startup_builtin_functions();
+	zend_register_scheduler_hook();
 	zend_register_standard_constants();
 	zend_register_auto_global(zend_string_init_interned("GLOBALS", sizeof("GLOBALS") - 1, 1), 1, php_auto_globals_create_globals);
 
@@ -1349,6 +1351,9 @@ ZEND_API void zend_deactivate(void) /* {{{ */
 {
 	/* we're no longer executing anything */
 	EG(current_execute_data) = NULL;
+
+	/* Drop any PHP-registered scheduler handlers held for this request. */
+	zend_scheduler_hook_request_shutdown();
 
 	zend_try {
 		shutdown_scanner();

--- a/Zend/zend_async_API.c
+++ b/Zend/zend_async_API.c
@@ -1,0 +1,435 @@
+/*
+   +----------------------------------------------------------------------+
+   | Copyright © The PHP Group and Contributors.                          |
+   +----------------------------------------------------------------------+
+   | This source file is subject to the Modified BSD License that is      |
+   | bundled with this package in the file LICENSE, and is available      |
+   | through the World Wide Web at <https://www.php.net/license/>.        |
+   |                                                                      |
+   | SPDX-License-Identifier: BSD-3-Clause                                |
+   +----------------------------------------------------------------------+
+   | Authors: Edmond <edmondifthen@proton.me>                             |
+   +----------------------------------------------------------------------+
+*/
+#include "zend_async_API.h"
+#include "zend_exceptions.h"
+
+///////////////////////////////////////////////////////////////////
+/// Globals
+///////////////////////////////////////////////////////////////////
+
+#ifdef ZTS
+ZEND_API int zend_async_globals_id = 0;
+ZEND_API size_t zend_async_globals_offset = 0;
+
+static void async_globals_ctor(zend_async_globals_t *globals)
+{
+	memset(globals, 0, sizeof(zend_async_globals_t));
+}
+
+static void async_globals_dtor(zend_async_globals_t *globals)
+{
+	(void) globals;
+}
+
+void zend_async_globals_ctor(void)
+{
+	ts_allocate_fast_id(&zend_async_globals_id, &zend_async_globals_offset,
+			sizeof(zend_async_globals_t), (ts_allocate_ctor) async_globals_ctor,
+			(ts_allocate_dtor) async_globals_dtor);
+}
+
+void zend_async_globals_dtor(void)
+{
+}
+#else
+ZEND_API zend_async_globals_t zend_async_globals_api = { 0 };
+
+void zend_async_globals_ctor(void)
+{
+	memset(&zend_async_globals_api, 0, sizeof(zend_async_globals_t));
+}
+
+void zend_async_globals_dtor(void)
+{
+}
+#endif
+
+///////////////////////////////////////////////////////////////////
+/// Internal context key registry
+///////////////////////////////////////////////////////////////////
+
+/*
+ * Maps a static C-string name to a process-unique numeric key.
+ * Keys are allocated once per process (typically at MINIT); the registry
+ * intentionally uses persistent memory and, under ZTS, a mutex.
+ */
+static HashTable *internal_context_key_names = NULL;
+static uint32_t internal_context_next_key = 1;
+#ifdef ZTS
+static MUTEX_T internal_context_mutex = NULL;
+#endif
+
+ZEND_API uint32_t zend_async_internal_context_key_alloc(const char *key_name)
+{
+#ifdef ZTS
+	if (internal_context_mutex == NULL) {
+		internal_context_mutex = tsrm_mutex_alloc();
+	}
+	tsrm_mutex_lock(internal_context_mutex);
+#endif
+
+	if (internal_context_key_names == NULL) {
+		internal_context_key_names = pemalloc(sizeof(HashTable), 1);
+		/* Values are static C strings owned by the callers - no destructor. */
+		zend_hash_init(internal_context_key_names, 8, NULL, NULL, 1);
+	}
+
+	const uint32_t key = internal_context_next_key++;
+	zend_hash_index_add_new_ptr(internal_context_key_names, key, (void *) key_name);
+
+#ifdef ZTS
+	tsrm_mutex_unlock(internal_context_mutex);
+#endif
+
+	return key;
+}
+
+ZEND_API const char *zend_async_internal_context_key_name(uint32_t key)
+{
+	if (internal_context_key_names == NULL) {
+		return NULL;
+	}
+
+	return zend_hash_index_find_ptr(internal_context_key_names, key);
+}
+
+static void internal_context_keys_shutdown(void)
+{
+	if (internal_context_key_names != NULL) {
+		zend_hash_destroy(internal_context_key_names);
+		pefree(internal_context_key_names, 1);
+		internal_context_key_names = NULL;
+	}
+
+	internal_context_next_key = 1;
+
+#ifdef ZTS
+	if (internal_context_mutex != NULL) {
+		tsrm_mutex_free(internal_context_mutex);
+		internal_context_mutex = NULL;
+	}
+#endif
+}
+
+///////////////////////////////////////////////////////////////////
+/// Default slot implementations (no scheduler registered)
+///////////////////////////////////////////////////////////////////
+
+static ZEND_COLD void throw_no_scheduler(void)
+{
+	zend_throw_error(NULL, "The Async API requires a scheduler implementation to be registered");
+}
+
+static zend_coroutine_t *new_coroutine_stub(size_t extra_size)
+{
+	(void) extra_size;
+	throw_no_scheduler();
+	return NULL;
+}
+
+static bool enqueue_coroutine_stub(zend_coroutine_t *coroutine)
+{
+	(void) coroutine;
+	throw_no_scheduler();
+	return false;
+}
+
+static bool suspend_stub(bool from_main, bool is_bailout)
+{
+	(void) from_main;
+	(void) is_bailout;
+	throw_no_scheduler();
+	return false;
+}
+
+static bool resume_stub(zend_coroutine_t *coroutine, zend_object *error, const bool transfer_error)
+{
+	(void) coroutine;
+	if (error != NULL && transfer_error) {
+		OBJ_RELEASE(error);
+	}
+	throw_no_scheduler();
+	return false;
+}
+
+static bool cancel_stub(
+		zend_coroutine_t *coroutine, zend_object *error, bool transfer_error, const bool is_safely)
+{
+	(void) coroutine;
+	(void) is_safely;
+	if (error != NULL && transfer_error) {
+		OBJ_RELEASE(error);
+	}
+	throw_no_scheduler();
+	return false;
+}
+
+static bool defer_stub(zend_async_microtask_t *task)
+{
+	(void) task;
+	throw_no_scheduler();
+	return false;
+}
+
+static bool bool_false_stub(void)
+{
+	return false;
+}
+
+static zend_async_context_t *get_context_stub(zend_coroutine_t *coroutine)
+{
+	(void) coroutine;
+	throw_no_scheduler();
+	return NULL;
+}
+
+static bool context_find_stub(
+		zend_async_context_t *context, zval *key, zval *result, bool include_parent)
+{
+	(void) context;
+	(void) key;
+	(void) include_parent;
+
+	if (result != NULL) {
+		ZVAL_NULL(result);
+	}
+
+	throw_no_scheduler();
+	return false;
+}
+
+static bool context_set_stub(zend_async_context_t *context, zval *key, zval *value)
+{
+	(void) context;
+	(void) key;
+	(void) value;
+	throw_no_scheduler();
+	return false;
+}
+
+static bool context_unset_stub(zend_async_context_t *context, zval *key)
+{
+	(void) context;
+	(void) key;
+	throw_no_scheduler();
+	return false;
+}
+
+static zval *internal_context_find_stub(zend_async_context_t *context, uint32_t key)
+{
+	(void) context;
+	(void) key;
+	throw_no_scheduler();
+	return NULL;
+}
+
+static bool internal_context_set_stub(zend_async_context_t *context, uint32_t key, zval *value)
+{
+	(void) context;
+	(void) key;
+	(void) value;
+	throw_no_scheduler();
+	return false;
+}
+
+static bool internal_context_unset_stub(zend_async_context_t *context, uint32_t key)
+{
+	(void) context;
+	(void) key;
+	throw_no_scheduler();
+	return false;
+}
+
+static zend_class_entry *get_class_ce_default(zend_async_class type)
+{
+	/* Without a scheduler there are no Async classes; every exception type
+	 * degrades to the base \Exception so error paths still work. */
+	if (type >= ZEND_ASYNC_EXCEPTION_DEFAULT) {
+		return zend_ce_exception;
+	}
+
+	return NULL;
+}
+
+static void default_call_on_main_stack(void (*fn)(void *), void *arg)
+{
+	fn(arg);
+}
+
+ZEND_API zend_async_new_coroutine_t zend_async_new_coroutine_fn = new_coroutine_stub;
+ZEND_API zend_async_enqueue_coroutine_t zend_async_enqueue_coroutine_fn = enqueue_coroutine_stub;
+ZEND_API zend_async_suspend_t zend_async_suspend_fn = suspend_stub;
+ZEND_API zend_async_resume_t zend_async_resume_fn = resume_stub;
+ZEND_API zend_async_cancel_t zend_async_cancel_fn = cancel_stub;
+ZEND_API zend_async_scheduler_launch_t zend_async_scheduler_launch_fn = bool_false_stub;
+ZEND_API zend_async_shutdown_t zend_async_shutdown_fn = bool_false_stub;
+ZEND_API zend_async_get_class_ce_t zend_async_get_class_ce_fn = get_class_ce_default;
+ZEND_API zend_async_call_on_main_stack_t zend_async_call_on_main_stack_fn =
+		default_call_on_main_stack;
+ZEND_API zend_async_get_context_t zend_async_get_context_fn = get_context_stub;
+ZEND_API zend_async_get_context_t zend_async_get_internal_context_fn = get_context_stub;
+ZEND_API zend_async_context_find_t zend_async_context_find_fn = context_find_stub;
+ZEND_API zend_async_context_set_t zend_async_context_set_fn = context_set_stub;
+ZEND_API zend_async_context_unset_t zend_async_context_unset_fn = context_unset_stub;
+ZEND_API zend_async_internal_context_find_t zend_async_internal_context_find_fn =
+		internal_context_find_stub;
+ZEND_API zend_async_internal_context_set_t zend_async_internal_context_set_fn =
+		internal_context_set_stub;
+ZEND_API zend_async_internal_context_unset_t zend_async_internal_context_unset_fn =
+		internal_context_unset_stub;
+ZEND_API zend_async_intercept_fiber_t zend_async_intercept_fiber_fn = NULL;
+ZEND_API zend_async_gc_destructors_t zend_async_gc_destructors_fn = NULL;
+ZEND_API zend_async_defer_t zend_async_defer_fn = defer_stub;
+
+static const char *scheduler_module_name = NULL;
+
+/* True when the field lies within the size the provider was compiled against. */
+#define API_PROVIDES(api, field) \
+	((api)->size >= offsetof(zend_async_scheduler_api_t, field) + sizeof((api)->field) \
+			&& (api)->field != NULL)
+
+ZEND_API bool zend_async_scheduler_register(
+		const char *module, const zend_async_scheduler_api_t *api)
+{
+	if (api == NULL || module == NULL) {
+		return false;
+	}
+
+	if ((api->version >> 16) != ZEND_ASYNC_API_VERSION_MAJOR) {
+		zend_error(E_CORE_WARNING,
+				"Module %s was compiled against an incompatible Async API version", module);
+		return false;
+	}
+
+	/* A scheduler is registered once per process. */
+	if (scheduler_module_name != NULL) {
+		zend_error(E_CORE_WARNING,
+				"The module %s cannot register an Async scheduler: %s already did",
+				module, scheduler_module_name);
+		return false;
+	}
+
+	if (API_PROVIDES(api, new_coroutine)) {
+		zend_async_new_coroutine_fn = api->new_coroutine;
+	}
+	if (API_PROVIDES(api, enqueue_coroutine)) {
+		zend_async_enqueue_coroutine_fn = api->enqueue_coroutine;
+	}
+	if (API_PROVIDES(api, suspend)) {
+		zend_async_suspend_fn = api->suspend;
+	}
+	if (API_PROVIDES(api, resume)) {
+		zend_async_resume_fn = api->resume;
+	}
+	if (API_PROVIDES(api, cancel)) {
+		zend_async_cancel_fn = api->cancel;
+	}
+	if (API_PROVIDES(api, launch)) {
+		zend_async_scheduler_launch_fn = api->launch;
+	}
+	if (API_PROVIDES(api, shutdown)) {
+		zend_async_shutdown_fn = api->shutdown;
+	}
+	if (API_PROVIDES(api, get_class_ce)) {
+		zend_async_get_class_ce_fn = api->get_class_ce;
+	}
+	if (API_PROVIDES(api, call_on_main_stack)) {
+		zend_async_call_on_main_stack_fn = api->call_on_main_stack;
+	}
+	if (API_PROVIDES(api, get_context)) {
+		zend_async_get_context_fn = api->get_context;
+	}
+	if (API_PROVIDES(api, get_internal_context)) {
+		zend_async_get_internal_context_fn = api->get_internal_context;
+	}
+	if (API_PROVIDES(api, context_find)) {
+		zend_async_context_find_fn = api->context_find;
+	}
+	if (API_PROVIDES(api, context_set)) {
+		zend_async_context_set_fn = api->context_set;
+	}
+	if (API_PROVIDES(api, context_unset)) {
+		zend_async_context_unset_fn = api->context_unset;
+	}
+	if (API_PROVIDES(api, internal_context_find)) {
+		zend_async_internal_context_find_fn = api->internal_context_find;
+	}
+	if (API_PROVIDES(api, internal_context_set)) {
+		zend_async_internal_context_set_fn = api->internal_context_set;
+	}
+	if (API_PROVIDES(api, internal_context_unset)) {
+		zend_async_internal_context_unset_fn = api->internal_context_unset;
+	}
+	if (API_PROVIDES(api, intercept_fiber)) {
+		zend_async_intercept_fiber_fn = api->intercept_fiber;
+	}
+
+	if (API_PROVIDES(api, gc_destructors)) {
+		zend_async_gc_destructors_fn = api->gc_destructors;
+	}
+
+	if (API_PROVIDES(api, defer)) {
+		zend_async_defer_fn = api->defer;
+	}
+
+	scheduler_module_name = module;
+
+	return true;
+}
+
+ZEND_API bool zend_async_is_enabled(void)
+{
+	return scheduler_module_name != NULL;
+}
+
+ZEND_API const char *zend_async_get_scheduler_module(void)
+{
+	return scheduler_module_name;
+}
+
+ZEND_API const char *zend_async_get_api_version(void)
+{
+	return ZEND_ASYNC_API;
+}
+
+ZEND_API int zend_async_get_api_version_number(void)
+{
+	return ZEND_ASYNC_API_VERSION_NUMBER;
+}
+
+void zend_async_api_shutdown(void)
+{
+	scheduler_module_name = NULL;
+
+	zend_async_new_coroutine_fn = new_coroutine_stub;
+	zend_async_enqueue_coroutine_fn = enqueue_coroutine_stub;
+	zend_async_suspend_fn = suspend_stub;
+	zend_async_resume_fn = resume_stub;
+	zend_async_cancel_fn = cancel_stub;
+	zend_async_scheduler_launch_fn = bool_false_stub;
+	zend_async_shutdown_fn = bool_false_stub;
+	zend_async_get_class_ce_fn = get_class_ce_default;
+	zend_async_call_on_main_stack_fn = default_call_on_main_stack;
+	zend_async_get_context_fn = get_context_stub;
+	zend_async_get_internal_context_fn = get_context_stub;
+	zend_async_context_find_fn = context_find_stub;
+	zend_async_context_set_fn = context_set_stub;
+	zend_async_context_unset_fn = context_unset_stub;
+	zend_async_internal_context_find_fn = internal_context_find_stub;
+	zend_async_internal_context_set_fn = internal_context_set_stub;
+	zend_async_internal_context_unset_fn = internal_context_unset_stub;
+	zend_async_intercept_fiber_fn = NULL;
+
+	internal_context_keys_shutdown();
+}

--- a/Zend/zend_async_API.h
+++ b/Zend/zend_async_API.h
@@ -1,0 +1,568 @@
+/*
+   +----------------------------------------------------------------------+
+   | Copyright © The PHP Group and Contributors.                          |
+   +----------------------------------------------------------------------+
+   | This source file is subject to the Modified BSD License that is      |
+   | bundled with this package in the file LICENSE, and is available      |
+   | through the World Wide Web at <https://www.php.net/license/>.        |
+   |                                                                      |
+   | SPDX-License-Identifier: BSD-3-Clause                                |
+   +----------------------------------------------------------------------+
+   | Authors: Edmond <edmondifthen@proton.me>                             |
+   +----------------------------------------------------------------------+
+*/
+#ifndef ZEND_ASYNC_API_H
+#define ZEND_ASYNC_API_H
+
+#include "zend_API.h"
+
+/*
+ * Async Core ABI.
+ *
+ * This header is intentionally thin: it contains only the coroutine data
+ * structure and the function-pointer slots a scheduler implementation
+ * fills in. It contains NO policy: no scheduler, no reactor, no event
+ * system. How a coroutine waits — and for what — is entirely the
+ * provider's business; the core only offers the awaiting_info hook so
+ * that the wait state can be inspected for diagnostics.
+ */
+#define ZEND_ASYNC_API "AsyncCore ABI v0.1.0"
+#define ZEND_ASYNC_API_VERSION_MAJOR 0
+#define ZEND_ASYNC_API_VERSION_MINOR 1
+#define ZEND_ASYNC_API_VERSION_PATCH 0
+
+#define ZEND_ASYNC_API_VERSION_NUMBER \
+	((ZEND_ASYNC_API_VERSION_MAJOR << 16) | (ZEND_ASYNC_API_VERSION_MINOR << 8) \
+			| (ZEND_ASYNC_API_VERSION_PATCH))
+
+typedef struct _zend_coroutine_s zend_coroutine_t;
+typedef struct _zend_async_context_s zend_async_context_t;
+typedef struct _zend_fcall_s zend_fcall_t;
+typedef struct _zend_fiber zend_fiber;
+typedef void (*zend_coroutine_entry_t)(void);
+
+/* Class/exception registry keys resolved through zend_async_get_class_ce_fn. */
+typedef enum {
+	ZEND_ASYNC_CLASS_NO = 0,
+	ZEND_ASYNC_CLASS_COROUTINE = 1,
+
+	ZEND_ASYNC_EXCEPTION_DEFAULT = 30,
+	ZEND_ASYNC_EXCEPTION_CANCELLATION = 31,
+} zend_async_class;
+
+struct _zend_fcall_s {
+	zend_fcall_info fci;
+	zend_fcall_info_cache fci_cache;
+};
+
+///////////////////////////////////////////////////////////////////
+/// Context
+///////////////////////////////////////////////////////////////////
+
+/*
+ * Execution-flow context: key/value storage bound to a coroutine
+ * (structured-concurrency context). Storage, inheritance and lifetime are
+ * the provider's business — the core only routes the calls and holds the
+ * single field it needs to bridge a context to a PHP object.
+ *
+ * The provider extends this by embedding it (its own fields follow, or the
+ * context shares one allocation with a zend_object exactly like a
+ * coroutine). A pure C context that has no PHP object leaves object_offset
+ * at 0.
+ *
+ * Keys are strings or objects (object identity). A non string/object
+ * key raises a TypeError and the call returns false.
+ */
+struct _zend_async_context_s {
+	/* Offset of the embedding zend_object within the allocation, or 0 when
+	 * the context has no PHP object. Symmetric with zend_coroutine_t. */
+	uint32_t object_offset;
+};
+
+/* The zend_object a context is embedded in, or NULL when it has none. */
+#define ZEND_ASYNC_CONTEXT_OBJECT(context) \
+	((context)->object_offset != 0 \
+			? (zend_object *) ((char *) (context) + (context)->object_offset) \
+			: NULL)
+
+/* Return the context of `coroutine`, creating it lazily.
+ * NULL means the currently running coroutine.
+ *
+ * The same signature serves two separate storages:
+ *  - get_context          - the userland context, zval keys;
+ *  - get_internal_context - a context reserved for C extensions with
+ *    NUMERIC keys, never visible to PHP code. */
+typedef zend_async_context_t *(*zend_async_get_context_t)(zend_coroutine_t *coroutine);
+/* Looks the key up in the context; when include_parent is true, the
+ * lookup continues along the inheritance chain. On success copies the
+ * value into `result` (when not NULL) and returns true; otherwise sets
+ * `result` to NULL and returns false. */
+typedef bool (*zend_async_context_find_t)(
+		zend_async_context_t *context, zval *key, zval *result, bool include_parent);
+typedef bool (*zend_async_context_set_t)(
+		zend_async_context_t *context, zval *key, zval *value);
+typedef bool (*zend_async_context_unset_t)(zend_async_context_t *context, zval *key);
+
+/*
+ * Internal context accessors. The context comes from get_internal_context;
+ * keys are NUMERIC: an extension allocates its key once per process from a
+ * static C-string name (zend_async_internal_context_key_alloc), then
+ * reads/writes values through the slots below. Values are destroyed when
+ * the owning coroutine completes.
+ */
+typedef zval *(*zend_async_internal_context_find_t)(
+		zend_async_context_t *context, uint32_t key);
+typedef bool (*zend_async_internal_context_set_t)(
+		zend_async_context_t *context, uint32_t key, zval *value);
+typedef bool (*zend_async_internal_context_unset_t)(
+		zend_async_context_t *context, uint32_t key);
+
+///////////////////////////////////////////////////////////////////
+/// Coroutine
+///////////////////////////////////////////////////////////////////
+
+typedef void (*zend_async_coroutine_dispose)(zend_coroutine_t *coroutine);
+
+/**
+ * Debug hook: returns a human-readable description of what the coroutine
+ * is currently waiting for (e.g. "poll: socket 12, readable" or
+ * "channel receive"). Assigned by whoever suspends the coroutine —
+ * scheduler, reactor, channel. The returned string is owned by the
+ * caller. May be NULL when nothing is known about the wait.
+ */
+typedef zend_string *(*zend_coroutine_awaiting_info_fn)(zend_coroutine_t *coroutine);
+
+/**
+ * Coroutine lifecycle. The single source of truth, managed by the
+ * scheduler. Maps 1:1 to the PHP-level is*() methods.
+ */
+typedef enum {
+	ZEND_COROUTINE_STATUS_CREATED = 0, /* spawned, never executed */
+	ZEND_COROUTINE_STATUS_QUEUED, /* ready, waiting in the run queue */
+	ZEND_COROUTINE_STATUS_RUNNING, /* currently executing */
+	ZEND_COROUTINE_STATUS_SUSPENDED, /* waiting; see awaiting_info */
+	ZEND_COROUTINE_STATUS_FINISHED /* completed; result or exception is set */
+} zend_coroutine_status;
+
+struct _zend_coroutine_s {
+	/* Bits 0-3: zend_coroutine_status (the scheduler is the only writer);
+	 * bits 4+: ZEND_COROUTINE_F_* modifiers. */
+	uint32_t flags;
+	/* Offset of the wrapping zend_object within the allocation, when the
+	 * coroutine is embedded in one (single-allocation pattern: the object
+	 * and the coroutine share one block, reached via container_of). 0 for
+	 * a plain C coroutine with no PHP object. */
+	uint32_t object_offset;
+	/* Userland entry point. NULL for internal coroutines. */
+	zend_fcall_t *fcall;
+	/* C entry point. NULL for userland coroutines. */
+	zend_coroutine_entry_t internal_entry;
+	/* Custom data of the scheduler/extension. Nullable. */
+	void *extended_data;
+	/* Completion result. */
+	zval result;
+	/* Completion exception. Nullable. */
+	zend_object *exception;
+	/* Spawn location (diagnostics). */
+	zend_string *filename;
+	uint32_t lineno;
+	/* Describes the current wait for diagnostics. Nullable. */
+	zend_coroutine_awaiting_info_fn awaiting_info;
+	/* Extended dispose handler. Nullable. */
+	zend_async_coroutine_dispose extended_dispose;
+};
+
+/* The lifecycle status is packed into the low 4 bits of `flags`. */
+#define ZEND_COROUTINE_STATUS_MASK 0xFu
+
+#define ZEND_COROUTINE_STATUS(coroutine) \
+	((zend_coroutine_status) ((coroutine)->flags & ZEND_COROUTINE_STATUS_MASK))
+#define ZEND_COROUTINE_SET_STATUS(coroutine, _status) \
+	((coroutine)->flags = \
+			((coroutine)->flags & ~ZEND_COROUTINE_STATUS_MASK) | (uint32_t) (_status))
+
+/* Orthogonal modifiers packed above the status bits. */
+#define ZEND_COROUTINE_F_CANCELLED (1u << 4) /* cancellation was requested */
+#define ZEND_COROUTINE_F_MAIN (1u << 5) /* the main coroutine */
+/* object_offset points at a stored zend_object* instead of an embedded
+ * object (used when the coroutine and its object live in different
+ * allocations, e.g. a coroutine bound to a Fiber). */
+#define ZEND_COROUTINE_F_OBJ_REF (1u << 6)
+
+#define ZEND_COROUTINE_IS_CANCELLED(coroutine) \
+	(((coroutine)->flags & ZEND_COROUTINE_F_CANCELLED) != 0)
+#define ZEND_COROUTINE_SET_CANCELLED(coroutine) \
+	((coroutine)->flags |= ZEND_COROUTINE_F_CANCELLED)
+
+#define ZEND_COROUTINE_IS_MAIN(coroutine) (((coroutine)->flags & ZEND_COROUTINE_F_MAIN) != 0)
+#define ZEND_COROUTINE_SET_MAIN(coroutine) ((coroutine)->flags |= ZEND_COROUTINE_F_MAIN)
+
+/* The zend_object of a coroutine, or NULL for a plain C coroutine.
+ * Embedded model: the object lives at object_offset within the same
+ * allocation. OBJ_REF model: a zend_object* is stored at object_offset. */
+#define ZEND_COROUTINE_OBJECT(coroutine) \
+	((coroutine)->object_offset == 0 \
+					? NULL \
+					: ((coroutine)->flags & ZEND_COROUTINE_F_OBJ_REF) \
+							? *(zend_object **) ((char *) (coroutine) + (coroutine)->object_offset) \
+							: (zend_object *) ((char *) (coroutine) + (coroutine)->object_offset))
+
+/* Lifecycle predicates over the packed status. */
+#define ZEND_COROUTINE_IS_STARTED(coroutine) \
+	(ZEND_COROUTINE_STATUS(coroutine) != ZEND_COROUTINE_STATUS_CREATED)
+#define ZEND_COROUTINE_IS_QUEUED(coroutine) \
+	(ZEND_COROUTINE_STATUS(coroutine) == ZEND_COROUTINE_STATUS_QUEUED)
+#define ZEND_COROUTINE_IS_RUNNING(coroutine) \
+	(ZEND_COROUTINE_STATUS(coroutine) == ZEND_COROUTINE_STATUS_RUNNING)
+#define ZEND_COROUTINE_IS_SUSPENDED(coroutine) \
+	(ZEND_COROUTINE_STATUS(coroutine) == ZEND_COROUTINE_STATUS_SUSPENDED)
+#define ZEND_COROUTINE_IS_FINISHED(coroutine) \
+	(ZEND_COROUTINE_STATUS(coroutine) == ZEND_COROUTINE_STATUS_FINISHED)
+
+/**
+ * Fetch the wait description of a suspended coroutine.
+ * NULL when the coroutine is not waiting or no info handler is assigned.
+ * The caller owns the returned string.
+ */
+#define ZEND_COROUTINE_AWAITING_INFO(coroutine) \
+	((coroutine)->awaiting_info != NULL ? (coroutine)->awaiting_info(coroutine) : NULL)
+
+/**
+ * Build a zend_fcall_t from PHP function parameters
+ * (Z_PARAM_FUNC + Z_PARAM_VARIADIC_WITH_NAMED).
+ */
+#define ZEND_ASYNC_FCALL_DEFINE(_fcall_var, _src_fci, _src_fcc, _src_args, _src_args_count, _src_named_args) \
+	zend_fcall_t *_fcall_var = ecalloc(1, sizeof(zend_fcall_t)); \
+	_fcall_var->fci = _src_fci; \
+	_fcall_var->fci_cache = _src_fcc; \
+	if (_src_args_count) { \
+		_fcall_var->fci.param_count = _src_args_count; \
+		_fcall_var->fci.params = safe_emalloc(_src_args_count, sizeof(zval), 0); \
+		for (uint32_t _fcall_i = 0; _fcall_i < _src_args_count; _fcall_i++) { \
+			ZVAL_COPY(&_fcall_var->fci.params[_fcall_i], &_src_args[_fcall_i]); \
+		} \
+	} \
+	if (_src_named_args) { \
+		_fcall_var->fci.named_params = _src_named_args; \
+		GC_ADDREF(_src_named_args); \
+	} \
+	Z_TRY_ADDREF(_fcall_var->fci.function_name);
+
+///////////////////////////////////////////////////////////////////
+/// Scheduler API slots
+///////////////////////////////////////////////////////////////////
+
+/* Allocate a coroutine in STATUS_CREATED; extra_size bytes are appended
+ * for the caller. */
+typedef zend_coroutine_t *(*zend_async_new_coroutine_t)(size_t extra_size);
+/* Put a CREATED/SUSPENDED coroutine into the run queue (-> STATUS_QUEUED). */
+typedef bool (*zend_async_enqueue_coroutine_t)(zend_coroutine_t *coroutine);
+/* Yield the current coroutine (-> STATUS_SUSPENDED) and give control to the
+ * scheduler. Returns after somebody resumes the coroutine; a delivered error
+ * is rethrown inside it, so the caller checks EG(exception) as usual.
+ * `from_main` = true is the after-main handoff: the main script (or its
+ * destructors) has finished and remaining coroutines get to run;
+ * `is_bailout` tells the scheduler the main flow ended with a bailout. */
+typedef bool (*zend_async_suspend_t)(bool from_main, bool is_bailout);
+/* Wake a suspended coroutine. When `error` is non-NULL it is thrown at the
+ * suspension point; transfer_error passes ownership of the reference. */
+typedef bool (*zend_async_resume_t)(
+		zend_coroutine_t *coroutine, zend_object *error, const bool transfer_error);
+/* Request cancellation: sets F_CANCELLED and wakes the coroutine with the
+ * error. `is_safely` defers delivery until a cancellation-safe point. */
+typedef bool (*zend_async_cancel_t)(
+		zend_coroutine_t *coroutine, zend_object *error, bool transfer_error, const bool is_safely);
+typedef bool (*zend_async_scheduler_launch_t)(void);
+typedef bool (*zend_async_shutdown_t)(void);
+typedef zend_class_entry *(*zend_async_get_class_ce_t)(zend_async_class type);
+/* Run fn(arg) on the main coroutine's OS-thread stack (FFI/JNI etc.). */
+typedef void (*zend_async_call_on_main_stack_t)(void (*fn)(void *), void *arg);
+/*
+ * Microtask: a one-shot task executed on the next scheduler tick.
+ *
+ * A structure with a lifetime: refcount ownership, cancellable at any
+ * moment. The consumer embeds it in its own container (container_of).
+ * The queue is OWNED BY THE PROVIDER; the core only routes the pointer
+ * through the defer slot. Provider tick contract:
+ *
+ *     if (!ZEND_ASYNC_MICROTASK_IS_CANCELLED(task)) task->handler(task);
+ *     ZEND_ASYNC_MICROTASK_RELEASE(task);
+ */
+typedef struct _zend_async_microtask_s zend_async_microtask_t;
+typedef void (*zend_async_microtask_handler_t)(zend_async_microtask_t *task);
+
+struct _zend_async_microtask_s {
+	/* Runs on the tick; NOT invoked for a cancelled task. */
+	zend_async_microtask_handler_t handler;
+	/* Releases the container's resources when the last reference dies.
+	 * NULL means a plain efree of the task. */
+	zend_async_microtask_handler_t dtor;
+	/* A full 32-bit reference counter. */
+	uint32_t ref_count;
+	/* 32 bits of named flags. */
+	uint32_t is_cancelled : 1;
+	uint32_t reserved : 31;
+};
+
+#define ZEND_ASYNC_MICROTASK_IS_CANCELLED(task) ((task)->is_cancelled != 0)
+#define ZEND_ASYNC_MICROTASK_CANCEL(task) ((task)->is_cancelled = 1)
+
+#define ZEND_ASYNC_MICROTASK_ADDREF(task) ((task)->ref_count++)
+
+#define ZEND_ASYNC_MICROTASK_RELEASE(task) \
+	do { \
+		if (--(task)->ref_count == 0) { \
+			if ((task)->dtor != NULL) { \
+				(task)->dtor(task); \
+			} \
+			efree(task); \
+		} \
+	} while (0)
+
+/* Queue the task on the provider's microtask queue. */
+typedef bool (*zend_async_defer_t)(zend_async_microtask_t *task);
+
+/*
+ * GC destructor phase interceptor (around).
+ *
+ * When the garbage collector reaches the destructor phase and the API is
+ * active, it calls this hook instead of running the phase directly. `run`
+ * is the engine's own destructor executor: the hook MUST call it (the
+ * engine re-runs any missed destructors afterwards as a safety net) and
+ * may bracket it with provider logic - typically opening a completion
+ * group before and awaiting everything the destructors spawned after.
+ * `run` is valid only for the duration of the phase.
+ */
+typedef bool (*zend_async_gc_run_dtors_fn)(void);
+typedef bool (*zend_async_gc_destructors_t)(zend_async_gc_run_dtors_fn run);
+
+/*
+ * The point where the engine links a fiber to a coroutine.
+ *
+ * There are two kinds of fibers: low-level ones (pure context switching,
+ * the primitive Revolt-style loops drive themselves; no coroutine) and
+ * high-level ones (fiber + coroutine, driven by the scheduler). Called by
+ * the engine on every Fiber::start() while the API is active, the hook
+ * decides which kind this fiber is:
+ *
+ *   returns a coroutine -> the engine binds it to the fiber
+ *                          (fiber->coroutine) and the fiber runs on the
+ *                          coroutine path;
+ *   returns NULL        -> the fiber keeps the legacy low-level behaviour.
+ *
+ * The coroutine is created by the scheduler, never by the engine. Because
+ * only the scheduler can tell its own internal fibers apart from
+ * application fibers, this also prevents self-recursion: the scheduler
+ * returns NULL for the fibers it drives itself. */
+typedef zend_coroutine_t *(*zend_async_intercept_fiber_t)(zend_fiber *fiber);
+
+/**
+ * Versioned scheduler API bundle. A provider fills the struct and calls
+ * zend_async_scheduler_register(). New slots are appended at the end only;
+ * `size` lets the core detect how much of the struct the provider knows.
+ */
+typedef struct _zend_async_scheduler_api_s {
+	uint32_t version; /* ZEND_ASYNC_API_VERSION_NUMBER the provider was built against */
+	size_t size; /* sizeof(zend_async_scheduler_api_t) at provider build time */
+
+	zend_async_new_coroutine_t new_coroutine;
+	zend_async_enqueue_coroutine_t enqueue_coroutine;
+	zend_async_suspend_t suspend;
+	zend_async_resume_t resume;
+	zend_async_cancel_t cancel;
+	zend_async_scheduler_launch_t launch;
+	zend_async_shutdown_t shutdown;
+	zend_async_get_class_ce_t get_class_ce;
+	zend_async_call_on_main_stack_t call_on_main_stack;
+	zend_async_get_context_t get_context;
+	zend_async_get_context_t get_internal_context;
+	zend_async_context_find_t context_find;
+	zend_async_context_set_t context_set;
+	zend_async_context_unset_t context_unset;
+	zend_async_internal_context_find_t internal_context_find;
+	zend_async_internal_context_set_t internal_context_set;
+	zend_async_internal_context_unset_t internal_context_unset;
+	zend_async_intercept_fiber_t intercept_fiber;
+	zend_async_gc_destructors_t gc_destructors;
+	zend_async_defer_t defer;
+} zend_async_scheduler_api_t;
+
+BEGIN_EXTERN_C()
+
+ZEND_API extern zend_async_new_coroutine_t zend_async_new_coroutine_fn;
+ZEND_API extern zend_async_enqueue_coroutine_t zend_async_enqueue_coroutine_fn;
+ZEND_API extern zend_async_suspend_t zend_async_suspend_fn;
+ZEND_API extern zend_async_resume_t zend_async_resume_fn;
+ZEND_API extern zend_async_cancel_t zend_async_cancel_fn;
+ZEND_API extern zend_async_scheduler_launch_t zend_async_scheduler_launch_fn;
+ZEND_API extern zend_async_shutdown_t zend_async_shutdown_fn;
+ZEND_API extern zend_async_get_class_ce_t zend_async_get_class_ce_fn;
+ZEND_API extern zend_async_call_on_main_stack_t zend_async_call_on_main_stack_fn;
+ZEND_API extern zend_async_get_context_t zend_async_get_context_fn;
+ZEND_API extern zend_async_get_context_t zend_async_get_internal_context_fn;
+ZEND_API extern zend_async_context_find_t zend_async_context_find_fn;
+ZEND_API extern zend_async_context_set_t zend_async_context_set_fn;
+ZEND_API extern zend_async_context_unset_t zend_async_context_unset_fn;
+ZEND_API extern zend_async_internal_context_find_t zend_async_internal_context_find_fn;
+ZEND_API extern zend_async_internal_context_set_t zend_async_internal_context_set_fn;
+ZEND_API extern zend_async_internal_context_unset_t zend_async_internal_context_unset_fn;
+ZEND_API extern zend_async_intercept_fiber_t zend_async_intercept_fiber_fn;
+ZEND_API extern zend_async_gc_destructors_t zend_async_gc_destructors_fn;
+ZEND_API extern zend_async_defer_t zend_async_defer_fn;
+
+/* Internal context key registry (implemented by the core): maps a static
+ * C-string name to a process-unique numeric key. Thread-safe under ZTS. */
+ZEND_API uint32_t zend_async_internal_context_key_alloc(const char *key_name);
+ZEND_API const char *zend_async_internal_context_key_name(uint32_t key);
+
+ZEND_API bool zend_async_scheduler_register(
+		const char *module, const zend_async_scheduler_api_t *api);
+
+ZEND_API bool zend_async_is_enabled(void);
+/* The module name of the registered scheduler, or NULL when none. */
+ZEND_API const char *zend_async_get_scheduler_module(void);
+ZEND_API const char *zend_async_get_api_version(void);
+ZEND_API int zend_async_get_api_version_number(void);
+
+END_EXTERN_C()
+
+#define ZEND_ASYNC_NEW_COROUTINE() zend_async_new_coroutine_fn(0)
+#define ZEND_ASYNC_NEW_COROUTINE_EX(extra_size) zend_async_new_coroutine_fn(extra_size)
+#define ZEND_ASYNC_ENQUEUE_COROUTINE(coroutine) zend_async_enqueue_coroutine_fn(coroutine)
+#define ZEND_ASYNC_SUSPEND() zend_async_suspend_fn(false, false)
+/* Hand control to the scheduler one last time after the main flow ends.
+ * Safe to call unconditionally: a no-op while the Async API is inactive. */
+#define ZEND_ASYNC_RUN_SCHEDULER_AFTER_MAIN(is_bailout) \
+	do { \
+		if (ZEND_ASYNC_IS_ACTIVE) { \
+			zend_async_suspend_fn(true, (is_bailout)); \
+		} \
+	} while (0)
+#define ZEND_ASYNC_RESUME(coroutine) zend_async_resume_fn((coroutine), NULL, false)
+#define ZEND_ASYNC_RESUME_WITH_ERROR(coroutine, error, transfer_error) \
+	zend_async_resume_fn((coroutine), (error), (transfer_error))
+#define ZEND_ASYNC_CANCEL(coroutine, error, transfer_error) \
+	zend_async_cancel_fn((coroutine), (error), (transfer_error), false)
+#define ZEND_ASYNC_SCHEDULER_LAUNCH() zend_async_scheduler_launch_fn()
+#define ZEND_ASYNC_SHUTDOWN() zend_async_shutdown_fn()
+#define ZEND_ASYNC_GET_CE(type) zend_async_get_class_ce_fn(type)
+#define ZEND_ASYNC_GET_EXCEPTION_CE(type) zend_async_get_class_ce_fn(type)
+#define ZEND_ASYNC_CALL_ON_MAIN_STACK(fn, arg) zend_async_call_on_main_stack_fn((fn), (arg))
+#define ZEND_ASYNC_DEFER(task) zend_async_defer_fn(task)
+
+/* The coroutine to bind to a starting fiber, or NULL for the legacy
+ * low-level path. A scheduler with no intercept_fiber slot leaves every
+ * fiber low-level. */
+#define ZEND_ASYNC_INTERCEPT_FIBER(fiber) \
+	((ZEND_ASYNC_IS_ACTIVE && zend_async_intercept_fiber_fn != NULL) \
+					? zend_async_intercept_fiber_fn(fiber) \
+					: NULL)
+
+#define ZEND_ASYNC_GET_CONTEXT(coroutine) zend_async_get_context_fn(coroutine)
+#define ZEND_ASYNC_CURRENT_CONTEXT ZEND_ASYNC_GET_CONTEXT(NULL)
+#define ZEND_ASYNC_GET_INTERNAL_CONTEXT(coroutine) zend_async_get_internal_context_fn(coroutine)
+#define ZEND_ASYNC_CURRENT_INTERNAL_CONTEXT ZEND_ASYNC_GET_INTERNAL_CONTEXT(NULL)
+#define ZEND_ASYNC_INTERNAL_CONTEXT_KEY_ALLOC(name) zend_async_internal_context_key_alloc(name)
+#define ZEND_ASYNC_INTERNAL_CONTEXT_FIND(context, key) \
+	zend_async_internal_context_find_fn((context), (key))
+#define ZEND_ASYNC_INTERNAL_CONTEXT_SET(context, key, value) \
+	zend_async_internal_context_set_fn((context), (key), (value))
+#define ZEND_ASYNC_INTERNAL_CONTEXT_UNSET(context, key) \
+	zend_async_internal_context_unset_fn((context), (key))
+#define ZEND_ASYNC_CONTEXT_FIND(context, key, result, include_parent) \
+	zend_async_context_find_fn((context), (key), (result), (include_parent))
+#define ZEND_ASYNC_CONTEXT_SET(context, key, value) \
+	zend_async_context_set_fn((context), (key), (value))
+#define ZEND_ASYNC_CONTEXT_UNSET(context, key) zend_async_context_unset_fn((context), (key))
+
+///////////////////////////////////////////////////////////////////
+/// Globals
+///////////////////////////////////////////////////////////////////
+
+typedef enum {
+	ZEND_ASYNC_OFF,
+	ZEND_ASYNC_READY,
+	ZEND_ASYNC_ACTIVE
+} zend_async_state_t;
+
+/*
+ * Storage of a PHP-registered scheduler (the Async\SchedulerHook bridge).
+ * Lives in the per-thread globals: the callables are request-local values.
+ * Hooks are addressed by index; the string names exist only to map the
+ * incoming array keys.
+ */
+typedef enum {
+	PHP_ASYNC_HOOK_LAUNCH = 0,
+	PHP_ASYNC_HOOK_SHUTDOWN,
+	PHP_ASYNC_HOOK_INTERCEPT_FIBER,
+	PHP_ASYNC_HOOK_ENQUEUE,
+	PHP_ASYNC_HOOK_SUSPEND,
+	PHP_ASYNC_HOOK_RESUME,
+	PHP_ASYNC_HOOK_CANCEL,
+	PHP_ASYNC_HOOK_CONTEXT_FIND,
+	PHP_ASYNC_HOOK_CONTEXT_SET,
+	PHP_ASYNC_HOOK_CONTEXT_UNSET,
+	PHP_ASYNC_HOOK_GC_DESTRUCTORS,
+	PHP_ASYNC_HOOK_DEFER,
+	PHP_ASYNC_HOOK_COUNT
+} php_async_hook_id;
+
+/* One stored PHP callable. `set` distinguishes "provided" from "absent". */
+typedef struct {
+	bool set;
+	zend_fcall_info fci;
+	zend_fcall_info_cache fcc;
+} php_async_hook_t;
+
+typedef struct {
+	bool active;
+	zend_string *module;
+	php_async_hook_t hooks[PHP_ASYNC_HOOK_COUNT];
+} php_async_handlers_t;
+
+typedef struct {
+	zend_async_state_t state;
+	/* Currently executing coroutine. NULL outside coroutine context. */
+	zend_coroutine_t *coroutine;
+	/* The main coroutine (top-level script on the OS thread stack). */
+	zend_coroutine_t *main_coroutine;
+	/* Number of live (not finished) coroutines. */
+	unsigned int active_coroutine_count;
+	/* True while scheduler code runs (a hook invocation, or the provider's
+	 * own machinery). Fiber operations on a bound fiber switch directly in
+	 * this context; application code routes through the hooks instead. */
+	bool in_scheduler_context;
+	/* PHP-registered scheduler hooks (the Async\SchedulerHook bridge). */
+	php_async_handlers_t scheduler_hooks;
+} zend_async_globals_t;
+
+BEGIN_EXTERN_C()
+#ifdef ZTS
+ZEND_API extern int zend_async_globals_id;
+ZEND_API extern size_t zend_async_globals_offset;
+#define ZEND_ASYNC_G(v) ZEND_TSRMG_FAST(zend_async_globals_offset, zend_async_globals_t *, v)
+#else
+ZEND_API extern zend_async_globals_t zend_async_globals_api;
+#define ZEND_ASYNC_G(v) (zend_async_globals_api.v)
+#endif
+
+void zend_async_globals_ctor(void);
+void zend_async_globals_dtor(void);
+void zend_async_api_shutdown(void);
+
+END_EXTERN_C()
+
+#define ZEND_ASYNC_ON (ZEND_ASYNC_G(state) > ZEND_ASYNC_OFF)
+#define ZEND_ASYNC_IS_ACTIVE (ZEND_ASYNC_G(state) == ZEND_ASYNC_ACTIVE)
+#define ZEND_ASYNC_IS_OFF (ZEND_ASYNC_G(state) == ZEND_ASYNC_OFF)
+#define ZEND_ASYNC_IS_READY (ZEND_ASYNC_G(state) == ZEND_ASYNC_READY)
+#define ZEND_ASYNC_ACTIVATE ZEND_ASYNC_G(state) = ZEND_ASYNC_ACTIVE
+#define ZEND_ASYNC_INITIALIZE ZEND_ASYNC_G(state) = ZEND_ASYNC_READY
+#define ZEND_ASYNC_DEACTIVATE ZEND_ASYNC_G(state) = ZEND_ASYNC_OFF
+
+#define ZEND_ASYNC_CURRENT_COROUTINE ZEND_ASYNC_G(coroutine)
+#define ZEND_ASYNC_MAIN_COROUTINE ZEND_ASYNC_G(main_coroutine)
+#define ZEND_ASYNC_ACTIVE_COROUTINE_COUNT ZEND_ASYNC_G(active_coroutine_count)
+#define ZEND_ASYNC_IN_SCHEDULER_CONTEXT ZEND_ASYNC_G(in_scheduler_context)
+
+#endif /* ZEND_ASYNC_API_H */

--- a/Zend/zend_fibers.c
+++ b/Zend/zend_fibers.c
@@ -810,6 +810,31 @@ static void zend_fiber_object_free(zend_object *object)
 
 	zval_ptr_dtor(&fiber->fci.function_name);
 	zval_ptr_dtor(&fiber->result);
+	zval_ptr_dtor(&fiber->transfer);
+
+	if (fiber->flags & ZEND_FIBER_FLAG_PARAMS_COPIED) {
+		for (uint32_t i = 0; i < fiber->fci.param_count; i++) {
+			zval_ptr_dtor(&fiber->fci.params[i]);
+		}
+
+		if (fiber->fci.params != NULL) {
+			efree(fiber->fci.params);
+		}
+
+		if (fiber->fci.named_params != NULL) {
+			zend_array_release(fiber->fci.named_params);
+		}
+	}
+
+	/* The coroutine handle is owned by whoever minted it; the dispose
+	 * handler knows how to release it. */
+	if (fiber->coroutine != NULL) {
+		if (fiber->coroutine->extended_dispose != NULL) {
+			fiber->coroutine->extended_dispose(fiber->coroutine);
+		}
+
+		fiber->coroutine = NULL;
+	}
 
 	zend_object_std_dtor(&fiber->std);
 }
@@ -821,6 +846,7 @@ static HashTable *zend_fiber_object_gc(zend_object *object, zval **table, int *n
 
 	zend_get_gc_buffer_add_zval(buf, &fiber->fci.function_name);
 	zend_get_gc_buffer_add_zval(buf, &fiber->result);
+	zend_get_gc_buffer_add_zval(buf, &fiber->transfer);
 
 	if (fiber->context.status != ZEND_FIBER_STATUS_SUSPENDED || fiber->caller != NULL) {
 		zend_get_gc_buffer_use(buf, table, num);
@@ -891,13 +917,123 @@ ZEND_METHOD(Fiber, __construct)
 	Z_TRY_ADDREF(fiber->fci.function_name);
 }
 
+/* Coroutine mode, scheduler context: switch directly into a bound fiber.
+ * Runs it until it yields or finishes; the yielded value (or completion
+ * NULL) is written to return_value. The scheduler reaches this through the
+ * plain Fiber API - there is no other switching primitive. */
+static void zend_fiber_scheduler_switch(zend_fiber *fiber, zval *return_value)
+{
+	zend_coroutine_t *coroutine = fiber->coroutine;
+
+	ZVAL_NULL(return_value);
+
+	if (UNEXPECTED(zend_fiber_switch_blocked())) {
+		zend_throw_error(zend_ce_fiber_error, "Cannot switch fibers in current execution context");
+		return;
+	}
+
+	/* Take the parked input (resume value or pending exception). */
+	const bool is_error = (fiber->flags & ZEND_FIBER_FLAG_ERROR_TRANSFER) != 0;
+	fiber->flags &= ~ZEND_FIBER_FLAG_ERROR_TRANSFER;
+
+	zval value;
+	ZVAL_COPY_VALUE(&value, &fiber->transfer);
+	ZVAL_UNDEF(&fiber->transfer);
+
+	if (fiber->context.status == ZEND_FIBER_STATUS_INIT) {
+		if (zend_fiber_init_context(&fiber->context, zend_ce_fiber, zend_fiber_execute,
+					EG(fiber_stack_size)) == FAILURE) {
+			zval_ptr_dtor(&value);
+			return;
+		}
+
+		fiber->previous = &fiber->context;
+	} else if (UNEXPECTED(fiber->context.status != ZEND_FIBER_STATUS_SUSPENDED
+					   || fiber->caller != NULL)) {
+		zval_ptr_dtor(&value);
+		zend_throw_error(zend_ce_fiber_error, "Cannot resume a fiber that is not suspended");
+		return;
+	} else {
+		fiber->stack_bottom->prev_execute_data = EG(current_execute_data);
+	}
+
+	ZEND_COROUTINE_SET_STATUS(coroutine, ZEND_COROUTINE_STATUS_RUNNING);
+
+	/* The fiber body is application code, not the scheduler. */
+	const bool saved_context = ZEND_ASYNC_IN_SCHEDULER_CONTEXT;
+	ZEND_ASYNC_IN_SCHEDULER_CONTEXT = false;
+
+	zend_fiber_transfer transfer = zend_fiber_resume_internal(
+			fiber, Z_ISUNDEF(value) ? NULL : &value, is_error);
+
+	ZEND_ASYNC_IN_SCHEDULER_CONTEXT = saved_context;
+
+	zval_ptr_dtor(&value);
+
+	if (fiber->context.status == ZEND_FIBER_STATUS_DEAD) {
+		ZEND_COROUTINE_SET_STATUS(coroutine, ZEND_COROUTINE_STATUS_FINISHED);
+
+		if (Z_ISUNDEF(coroutine->result) && !Z_ISUNDEF(fiber->result)) {
+			ZVAL_COPY(&coroutine->result, &fiber->result);
+		}
+	} else {
+		ZEND_COROUTINE_SET_STATUS(coroutine, ZEND_COROUTINE_STATUS_SUSPENDED);
+
+		/* Park a copy of the yield for the start()/resume() reader. */
+		if (!(transfer.flags & ZEND_FIBER_TRANSFER_FLAG_ERROR)) {
+			zval_ptr_dtor(&fiber->transfer);
+			ZVAL_COPY(&fiber->transfer, &transfer.value);
+		}
+	}
+
+	/* Deliver the yield (or the escaped exception) to the switchTo caller. */
+	if (transfer.flags & ZEND_FIBER_TRANSFER_FLAG_ERROR) {
+		zend_throw_exception_internal(Z_OBJ(transfer.value));
+	} else {
+		ZVAL_COPY_VALUE(return_value, &transfer.value);
+	}
+}
+
+/* Coroutine mode: wait until the fiber yields (or finishes) and return the
+ * yielded value. Hands control to the scheduler, which continues coroutines
+ * through switchTo; when it hands control back, the value the fiber parked
+ * on yield becomes the result (NULL when it finished or was not run). */
+static void zend_fiber_wait_for_yield(zend_fiber *fiber, zval *return_value)
+{
+	ZEND_ASYNC_SUSPEND();
+
+	if (UNEXPECTED(EG(exception))) {
+		RETVAL_NULL();
+		return;
+	}
+
+	if (Z_ISUNDEF(fiber->transfer)) {
+		RETVAL_NULL();
+	} else {
+		RETVAL_COPY_VALUE(&fiber->transfer);
+		ZVAL_UNDEF(&fiber->transfer);
+	}
+}
+
 ZEND_METHOD(Fiber, start)
 {
 	zend_fiber *fiber = (zend_fiber *) Z_OBJ_P(ZEND_THIS);
+	zval *args;
+	uint32_t argc;
+	HashTable *named_args;
 
 	ZEND_PARSE_PARAMETERS_START(0, -1)
-		Z_PARAM_VARIADIC_WITH_NAMED(fiber->fci.params, fiber->fci.param_count, fiber->fci.named_params);
+		Z_PARAM_VARIADIC_WITH_NAMED(args, argc, named_args);
 	ZEND_PARSE_PARAMETERS_END();
+
+	/* Bind the arguments. A scheduler-context restart with no arguments
+	 * keeps the ones the application call bound. */
+	if (!(ZEND_ASYNC_IN_SCHEDULER_CONTEXT && fiber->coroutine != NULL && argc == 0
+				&& named_args == NULL)) {
+		fiber->fci.params = args;
+		fiber->fci.param_count = argc;
+		fiber->fci.named_params = named_args;
+	}
 
 	if (UNEXPECTED(zend_fiber_switch_blocked())) {
 		zend_throw_error(zend_ce_fiber_error, "Cannot switch fibers in current execution context");
@@ -907,6 +1043,55 @@ ZEND_METHOD(Fiber, start)
 	if (fiber->context.status != ZEND_FIBER_STATUS_INIT) {
 		zend_throw_error(zend_ce_fiber_error, "Cannot start a fiber that has already been started");
 		RETURN_THROWS();
+	}
+
+	/* Coroutine mode: the scheduler may bind a coroutine to this fiber.
+	 * NULL keeps the fiber on the low-level path. */
+	if (fiber->coroutine == NULL) {
+		fiber->coroutine = ZEND_ASYNC_INTERCEPT_FIBER(fiber);
+
+		if (fiber->coroutine != NULL && fiber->coroutine->extended_data == NULL) {
+			fiber->coroutine->extended_data = fiber;
+		}
+	}
+
+	if (fiber->coroutine != NULL) {
+		/* The scheduler runs a bound fiber directly through the plain
+		 * Fiber API; application code hands over to the scheduler. */
+		if (ZEND_ASYNC_IN_SCHEDULER_CONTEXT) {
+			zend_fiber_scheduler_switch(fiber, return_value);
+
+			if (UNEXPECTED(EG(exception))) {
+				RETURN_THROWS();
+			}
+
+			return;
+		}
+
+		/* The start is deferred: the arguments must survive this call
+		 * frame, so the fiber takes an owned deep copy. */
+		if (fiber->fci.param_count > 0) {
+			zval *copy = safe_emalloc(fiber->fci.param_count, sizeof(zval), 0);
+
+			for (uint32_t i = 0; i < fiber->fci.param_count; i++) {
+				ZVAL_COPY(&copy[i], &fiber->fci.params[i]);
+			}
+
+			fiber->fci.params = copy;
+			fiber->flags |= ZEND_FIBER_FLAG_PARAMS_COPIED;
+		}
+
+		if (fiber->fci.named_params != NULL) {
+			GC_ADDREF(fiber->fci.named_params);
+			fiber->flags |= ZEND_FIBER_FLAG_PARAMS_COPIED;
+		}
+
+		if (!ZEND_ASYNC_ENQUEUE_COROUTINE(fiber->coroutine) || EG(exception)) {
+			RETURN_THROWS();
+		}
+
+		zend_fiber_wait_for_yield(fiber, return_value);
+		return;
 	}
 
 	if (zend_fiber_init_context(&fiber->context, zend_ce_fiber, zend_fiber_execute, EG(fiber_stack_size)) == FAILURE) {
@@ -977,6 +1162,44 @@ ZEND_METHOD(Fiber, resume)
 		RETURN_THROWS();
 	}
 
+	/* Coroutine mode: the scheduler switches directly; application code
+	 * parks the value, notifies the scheduler and lets it drive. */
+	if (fiber->coroutine != NULL) {
+		if (ZEND_ASYNC_IN_SCHEDULER_CONTEXT) {
+			/* An explicit value overrides the parked one. */
+			if (value != NULL) {
+				zval_ptr_dtor(&fiber->transfer);
+				ZVAL_COPY(&fiber->transfer, value);
+				fiber->flags &= ~ZEND_FIBER_FLAG_ERROR_TRANSFER;
+			}
+
+			zend_fiber_scheduler_switch(fiber, return_value);
+
+			if (UNEXPECTED(EG(exception))) {
+				RETURN_THROWS();
+			}
+
+			return;
+		}
+
+		zval_ptr_dtor(&fiber->transfer);
+
+		if (value != NULL) {
+			ZVAL_COPY(&fiber->transfer, value);
+		} else {
+			ZVAL_UNDEF(&fiber->transfer);
+		}
+
+		fiber->flags &= ~ZEND_FIBER_FLAG_ERROR_TRANSFER;
+
+		if (!ZEND_ASYNC_RESUME(fiber->coroutine) || EG(exception)) {
+			RETURN_THROWS();
+		}
+
+		zend_fiber_wait_for_yield(fiber, return_value);
+		return;
+	}
+
 	fiber->stack_bottom->prev_execute_data = EG(current_execute_data);
 
 	zend_fiber_transfer transfer = zend_fiber_resume_internal(fiber, value, false);
@@ -1003,6 +1226,33 @@ ZEND_METHOD(Fiber, throw)
 	if (UNEXPECTED(fiber->context.status != ZEND_FIBER_STATUS_SUSPENDED || fiber->caller != NULL)) {
 		zend_throw_error(zend_ce_fiber_error, "Cannot resume a fiber that is not suspended");
 		RETURN_THROWS();
+	}
+
+	/* Coroutine mode: park the exception; the scheduler switches directly
+	 * (the throw happens at the suspension point), application code
+	 * notifies the scheduler and lets it drive. */
+	if (fiber->coroutine != NULL) {
+		zval_ptr_dtor(&fiber->transfer);
+		ZVAL_COPY(&fiber->transfer, exception);
+		fiber->flags |= ZEND_FIBER_FLAG_ERROR_TRANSFER;
+
+		if (ZEND_ASYNC_IN_SCHEDULER_CONTEXT) {
+			zend_fiber_scheduler_switch(fiber, return_value);
+
+			if (UNEXPECTED(EG(exception))) {
+				RETURN_THROWS();
+			}
+
+			return;
+		}
+
+		if (!ZEND_ASYNC_RESUME_WITH_ERROR(fiber->coroutine, Z_OBJ_P(exception), false)
+				|| EG(exception)) {
+			RETURN_THROWS();
+		}
+
+		zend_fiber_wait_for_yield(fiber, return_value);
+		return;
 	}
 
 	fiber->stack_bottom->prev_execute_data = EG(current_execute_data);

--- a/Zend/zend_fibers.h
+++ b/Zend/zend_fibers.h
@@ -21,6 +21,7 @@
 
 #include "zend_API.h"
 #include "zend_types.h"
+#include "zend_async_API.h"
 
 #define ZEND_FIBER_GUARD_PAGES 1
 
@@ -40,6 +41,12 @@ typedef enum {
 	ZEND_FIBER_FLAG_THREW     = 1 << 0,
 	ZEND_FIBER_FLAG_BAILOUT   = 1 << 1,
 	ZEND_FIBER_FLAG_DESTROYED = 1 << 2,
+	/* The parked transfer value is an exception to throw at the
+	 * suspension point (coroutine mode only). */
+	ZEND_FIBER_FLAG_ERROR_TRANSFER = 1 << 3,
+	/* fci.params is a fiber-owned deep copy (coroutine mode: a deferred
+	 * start must not reference the caller's dead stack frame). */
+	ZEND_FIBER_FLAG_PARAMS_COPIED = 1 << 4,
 } zend_fiber_flag;
 
 typedef enum {
@@ -108,8 +115,20 @@ struct _zend_fiber {
 	/* Native C fiber context. */
 	zend_fiber_context context;
 
-	/* Fiber that resumed us. */
-	zend_fiber_context *caller;
+	/*
+	 * Associated coroutine, when a scheduler is active. NULL in legacy
+	 * mode: the fiber then blocks the thread exactly as before. When set,
+	 * the fiber's wait becomes cooperative - resume/suspend route through
+	 * the scheduler slots instead of switching fiber contexts directly.
+	 */
+	zend_coroutine_t *coroutine;
+
+	union {
+		/* Fiber that resumed us (legacy mode, coroutine == NULL). */
+		zend_fiber_context *caller;
+		/* Coroutine that resumed us (coroutine mode). */
+		zend_coroutine_t *caller_coroutine;
+	};
 
 	/* Fiber that suspended us. */
 	zend_fiber_context *previous;
@@ -129,6 +148,15 @@ struct _zend_fiber {
 
 	/* Storage for fiber return value. */
 	zval result;
+
+	/*
+	 * Coroutine mode only: the value crossing the scheduler boundary.
+	 * Before a switch it holds the pending resume value (or the exception
+	 * when ZEND_FIBER_FLAG_ERROR_TRANSFER is set); after a yield it holds
+	 * the value the fiber suspended with, so start()/resume() can return
+	 * it once the scheduler hands control back.
+	 */
+	zval transfer;
 };
 
 ZEND_API zend_result zend_fiber_start(zend_fiber *fiber, zval *return_value);

--- a/Zend/zend_gc.c
+++ b/Zend/zend_gc.c
@@ -70,6 +70,7 @@
 #include "zend_compile.h"
 #include "zend_errors.h"
 #include "zend_fibers.h"
+#include "zend_async_API.h"
 #include "zend_hrtime.h"
 #include "zend_portability.h"
 #include "zend_types.h"
@@ -293,6 +294,9 @@ typedef struct _zend_gc_globals {
 	uint32_t dtor_end;
 	zend_fiber *dtor_fiber;
 	bool dtor_fiber_running;
+	/* The destructor phase is active: zend_gc_run_pending_destructors()
+	 * is allowed to run. */
+	bool dtor_phase_active;
 
 #if GC_BENCH
 	uint32_t root_buf_length;
@@ -535,6 +539,7 @@ static void gc_globals_ctor_ex(zend_gc_globals *gc_globals)
 	gc_globals->dtor_end = 0;
 	gc_globals->dtor_fiber = NULL;
 	gc_globals->dtor_fiber_running = false;
+	gc_globals->dtor_phase_active = false;
 
 #if GC_BENCH
 	gc_globals->root_buf_length = 0;
@@ -583,6 +588,7 @@ void gc_reset(void)
 		GC_G(dtor_end) = 0;
 		GC_G(dtor_fiber) = NULL;
 		GC_G(dtor_fiber_running) = false;
+		GC_G(dtor_phase_active) = false;
 
 #if GC_BENCH
 		GC_G(root_buf_length) = 0;
@@ -1892,7 +1898,15 @@ static zend_always_inline zend_result gc_call_destructors(uint32_t idx, uint32_t
 				GC_TRACE_REF(obj, "calling destructor");
 				GC_ADD_FLAGS(obj, IS_OBJ_DESTRUCTOR_CALLED);
 				GC_ADDREF(obj);
+
+				/* A destructor is application code even when the phase runs
+				 * inside a scheduler hook. */
+				const bool saved_context = ZEND_ASYNC_IN_SCHEDULER_CONTEXT;
+				ZEND_ASYNC_IN_SCHEDULER_CONTEXT = false;
+
 				obj->handlers->dtor_obj(obj);
+
+				ZEND_ASYNC_IN_SCHEDULER_CONTEXT = saved_context;
 				GC_TRACE_REF(obj, "returned from destructor");
 				GC_DELREF(obj);
 				if (UNEXPECTED(fiber != NULL && GC_G(dtor_fiber) != fiber)) {
@@ -1988,6 +2002,29 @@ static zend_never_inline void gc_call_destructors_in_fiber(void)
 	}
 
 	EG(exception) = exception;
+}
+
+/* The engine's destructor-phase executor handed to the gc_destructors
+ * hook. Re-runnable while the phase is active: already-called destructors
+ * are skipped by the IS_OBJ_DESTRUCTOR_CALLED flag. */
+static bool gc_run_destructor_phase(void)
+{
+	if (!GC_G(dtor_phase_active)) {
+		return false;
+	}
+
+	if (EXPECTED(!EG(active_fiber))) {
+		gc_call_destructors(GC_FIRST_ROOT, GC_G(first_unused), NULL);
+	} else {
+		gc_call_destructors_in_fiber();
+	}
+
+	return true;
+}
+
+ZEND_API bool zend_gc_run_pending_destructors(void)
+{
+	return gc_run_destructor_phase();
 }
 
 /* Perform a garbage collection run. The default implementation of gc_collect_cycles. */
@@ -2091,11 +2128,21 @@ rerun_gc:
 
 			/* Actually call destructors. */
 			zend_hrtime_t dtor_start_time = zend_hrtime();
-			if (EXPECTED(!EG(active_fiber))) {
-				gc_call_destructors(GC_FIRST_ROOT, end, NULL);
+			GC_G(dtor_phase_active) = true;
+
+			if (UNEXPECTED(ZEND_ASYNC_IS_ACTIVE && zend_async_gc_destructors_fn != NULL)) {
+				/* The provider brackets the phase (e.g. opens a completion
+				 * group and awaits everything the destructors spawned). */
+				zend_async_gc_destructors_fn(gc_run_destructor_phase);
+
+				/* Safety net: the hook cannot prevent destructors from
+				 * running - execute any that were missed. */
+				gc_run_destructor_phase();
 			} else {
-				gc_call_destructors_in_fiber();
+				gc_run_destructor_phase();
 			}
+
+			GC_G(dtor_phase_active) = false;
 			GC_G(dtor_time) += zend_hrtime() - dtor_start_time;
 
 			if (GC_G(gc_protected)) {

--- a/Zend/zend_gc.h
+++ b/Zend/zend_gc.h
@@ -61,6 +61,10 @@ void gc_bench_print(void);
 
 /* The default implementation of the gc_collect_cycles callback. */
 ZEND_API int  zend_gc_collect_cycles(void);
+/* Run the destructors pending in the current GC destructor phase. Valid
+ * only while the phase is active (from inside the gc_destructors hook);
+ * otherwise a no-op returning false. */
+ZEND_API bool zend_gc_run_pending_destructors(void);
 
 ZEND_API void zend_gc_get_status(zend_gc_status *status);
 

--- a/Zend/zend_scheduler_hook.c
+++ b/Zend/zend_scheduler_hook.c
@@ -1,0 +1,582 @@
+/*
+   +----------------------------------------------------------------------+
+   | Copyright © The PHP Group and Contributors.                          |
+   +----------------------------------------------------------------------+
+   | This source file is subject to the Modified BSD License that is      |
+   | bundled with this package in the file LICENSE, and is available      |
+   | through the World Wide Web at <https://www.php.net/license/>.        |
+   |                                                                      |
+   | SPDX-License-Identifier: BSD-3-Clause                                |
+   +----------------------------------------------------------------------+
+   | Authors: Edmond <edmondifthen@proton.me>                             |
+   +----------------------------------------------------------------------+
+*/
+
+/*
+ * The PHP registration bridge for the Async Core.
+ *
+ * Async\SchedulerHook::register() lets a scheduler written in PHP fill the
+ * engine's scheduler slots with plain callables. Each slot is backed by a
+ * C thunk that forwards to the stored callable.
+ *
+ * The coroutine itself is defined by external code (the scheduler /
+ * provider): the bridge never creates a coroutine object, it only unwraps
+ * a zend_coroutine_t to the object the provider embedded it in.
+ *
+ * NOTE: this file compiles but is not yet runtime-tested — it needs a full
+ * build and a reference scheduler to exercise. The context accessors are a
+ * follow-up.
+ */
+
+#include "zend_scheduler_hook.h"
+#include "zend_async_API.h"
+#include "zend_scheduler_hook_arginfo.h"
+#include "zend_fibers.h"
+#include "zend_exceptions.h"
+#include "zend_closures.h"
+
+/* The hook names, indexed by php_async_hook_id: used only to map the
+ * incoming array keys (the Async\SchedulerHook class constants). */
+static const struct {
+	const char *name;
+	size_t len;
+} php_async_hook_names[PHP_ASYNC_HOOK_COUNT] = {
+	[PHP_ASYNC_HOOK_LAUNCH] = { ZEND_STRL("launch") },
+	[PHP_ASYNC_HOOK_SHUTDOWN] = { ZEND_STRL("shutdown") },
+	[PHP_ASYNC_HOOK_INTERCEPT_FIBER] = { ZEND_STRL("intercept_fiber") },
+	[PHP_ASYNC_HOOK_ENQUEUE] = { ZEND_STRL("enqueue_coroutine") },
+	[PHP_ASYNC_HOOK_SUSPEND] = { ZEND_STRL("suspend") },
+	[PHP_ASYNC_HOOK_RESUME] = { ZEND_STRL("resume") },
+	[PHP_ASYNC_HOOK_CANCEL] = { ZEND_STRL("cancel") },
+	[PHP_ASYNC_HOOK_CONTEXT_FIND] = { ZEND_STRL("context_find") },
+	[PHP_ASYNC_HOOK_CONTEXT_SET] = { ZEND_STRL("context_set") },
+	[PHP_ASYNC_HOOK_CONTEXT_UNSET] = { ZEND_STRL("context_unset") },
+	[PHP_ASYNC_HOOK_GC_DESTRUCTORS] = { ZEND_STRL("gc_destructors") },
+	[PHP_ASYNC_HOOK_DEFER] = { ZEND_STRL("defer") },
+};
+
+/* The storage lives in the per-thread async globals: correct under ZTS,
+ * request-local by construction. */
+#define PHP_ASYNC_HANDLERS (ZEND_ASYNC_G(scheduler_hooks))
+#define PHP_ASYNC_HOOK(id) (&PHP_ASYNC_HANDLERS.hooks[(id)])
+
+/* Read the callable for `id` from the incoming array into storage. */
+static bool php_async_hook_take(HashTable *array, php_async_hook_id id)
+{
+	php_async_hook_t *hook = PHP_ASYNC_HOOK(id);
+	zval *entry = zend_hash_str_find(array, php_async_hook_names[id].name, php_async_hook_names[id].len);
+
+	if (entry == NULL) {
+		hook->set = false;
+		return true;
+	}
+
+	char *error = NULL;
+
+	if (zend_fcall_info_init(entry, 0, &hook->fci, &hook->fcc, NULL, &error) != SUCCESS) {
+		zend_type_error("Async scheduler hook \"%s\" must be a valid callable: %s",
+				php_async_hook_names[id].name, error != NULL ? error : "unknown error");
+		if (error != NULL) {
+			efree(error);
+		}
+
+		return false;
+	}
+
+	if (error != NULL) {
+		efree(error);
+	}
+
+	/* Keep the callable alive for the whole request. */
+	Z_TRY_ADDREF(hook->fci.function_name);
+	if (hook->fci.object != NULL) {
+		GC_ADDREF(hook->fci.object);
+	}
+
+	hook->set = true;
+	return true;
+}
+
+static void php_async_hook_release(php_async_hook_t *hook)
+{
+	if (!hook->set) {
+		return;
+	}
+
+	zval_ptr_dtor(&hook->fci.function_name);
+
+	if (hook->fci.object != NULL) {
+		OBJ_RELEASE(hook->fci.object);
+	}
+
+	hook->set = false;
+}
+
+/* Call a stored hook with `argc` prepared arguments; result in `retval`
+ * (caller owns it). Returns false when the hook is absent or the call fails. */
+static bool php_async_hook_call(php_async_hook_t *hook, uint32_t argc, zval *argv, zval *retval)
+{
+	if (!hook->set) {
+		ZVAL_UNDEF(retval);
+		return false;
+	}
+
+	hook->fci.param_count = argc;
+	hook->fci.params = argv;
+	hook->fci.retval = retval;
+
+	/* A hook invocation IS scheduler code: bound-fiber operations inside
+	 * it switch directly instead of routing back through the hooks. */
+	const bool saved_context = ZEND_ASYNC_IN_SCHEDULER_CONTEXT;
+	ZEND_ASYNC_IN_SCHEDULER_CONTEXT = true;
+
+	const bool ok = zend_call_function(&hook->fci, &hook->fcc) == SUCCESS && !EG(exception);
+
+	ZEND_ASYNC_IN_SCHEDULER_CONTEXT = saved_context;
+
+	return ok;
+}
+
+static bool php_async_hook_call_bool(php_async_hook_id id, uint32_t argc, zval *argv)
+{
+	zval retval;
+
+	if (!php_async_hook_call(PHP_ASYNC_HOOK(id), argc, argv, &retval)) {
+		return false;
+	}
+
+	const bool ok = zend_is_true(&retval);
+	zval_ptr_dtor(&retval);
+	return ok;
+}
+
+/////////////////////////////////////////////////////////////////////
+/// Non-coroutine thunks
+/////////////////////////////////////////////////////////////////////
+
+static bool php_async_thunk_launch(void)
+{
+	return php_async_hook_call_bool(PHP_ASYNC_HOOK_LAUNCH, 0, NULL);
+}
+
+static bool php_async_thunk_shutdown(void)
+{
+	return php_async_hook_call_bool(PHP_ASYNC_HOOK_SHUTDOWN, 0, NULL);
+}
+
+/*
+ * The coroutine handle the bridge mints for a coroutine object returned by
+ * the PHP intercept_fiber hook. The scheduler's coroutine is a plain PHP
+ * object, so the engine-visible zend_coroutine_t lives in its own small
+ * allocation and reaches the object through a stored pointer (OBJ_REF).
+ * The handle holds one reference to the object; both are released by the
+ * fiber teardown once phase 2 wires it (TODO).
+ */
+typedef struct {
+	zend_coroutine_t coro;
+	zend_object *object;
+} php_coroutine_t;
+
+/* Release a minted handle: the fiber teardown calls this via
+ * coro->extended_dispose. */
+static void php_async_coroutine_dispose(zend_coroutine_t *coro)
+{
+	php_coroutine_t *handle = (php_coroutine_t *) coro;
+
+	zval_ptr_dtor(&coro->result);
+
+	if (coro->exception != NULL) {
+		OBJ_RELEASE(coro->exception);
+	}
+
+	if (handle->object != NULL) {
+		OBJ_RELEASE(handle->object);
+	}
+
+	efree(handle);
+}
+
+static zend_coroutine_t *php_async_thunk_intercept_fiber(zend_fiber *fiber)
+{
+	zval arg, retval;
+	ZVAL_OBJ(&arg, &fiber->std);
+	GC_ADDREF(&fiber->std);
+
+	const bool ok = php_async_hook_call(
+			PHP_ASYNC_HOOK(PHP_ASYNC_HOOK_INTERCEPT_FIBER), 1, &arg, &retval);
+
+	zval_ptr_dtor(&arg);
+
+	if (!ok || Z_TYPE(retval) != IS_OBJECT) {
+		/* NULL (or any non-object) keeps the fiber on the low-level path. */
+		zval_ptr_dtor(&retval);
+		return NULL;
+	}
+
+	php_coroutine_t *adopted = ecalloc(1, sizeof(*adopted));
+
+	adopted->object = Z_OBJ(retval); /* takes over the retval reference */
+	adopted->coro.flags = ZEND_COROUTINE_F_OBJ_REF;
+	adopted->coro.object_offset = offsetof(php_coroutine_t, object);
+	adopted->coro.extended_data = fiber;
+	adopted->coro.extended_dispose = php_async_coroutine_dispose;
+	ZVAL_UNDEF(&adopted->coro.result);
+
+	return &adopted->coro;
+}
+
+/////////////////////////////////////////////////////////////////////
+/// Coroutine-carrying thunks
+/////////////////////////////////////////////////////////////////////
+
+/* The coroutine's PHP object as a zval, with a borrowed +1 for the call.
+ * The object is defined by external code (the scheduler / provider) and
+ * reached through coro->object_offset. */
+static void php_async_coroutine_arg(zend_coroutine_t *coro, zval *out)
+{
+	zend_object *object = ZEND_COROUTINE_OBJECT(coro);
+
+	if (object != NULL) {
+		ZVAL_OBJ(out, object);
+		GC_ADDREF(object);
+	} else {
+		ZVAL_NULL(out);
+	}
+}
+
+static bool php_async_thunk_enqueue(zend_coroutine_t *coro)
+{
+	zval arg;
+	php_async_coroutine_arg(coro, &arg);
+
+	const bool result = php_async_hook_call_bool(PHP_ASYNC_HOOK_ENQUEUE, 1, &arg);
+
+	zval_ptr_dtor(&arg);
+	return result;
+}
+
+static bool php_async_thunk_suspend(bool from_main, bool is_bailout)
+{
+	zval args[2];
+	ZVAL_BOOL(&args[0], from_main);
+	ZVAL_BOOL(&args[1], is_bailout);
+
+	return php_async_hook_call_bool(PHP_ASYNC_HOOK_SUSPEND, 2, args);
+}
+
+/* Shared body for resume/cancel: (coroutine, ?error). transfer_error hands
+ * over ownership of the error reference to the call. */
+static bool php_async_thunk_wake(php_async_hook_id id, zend_coroutine_t *coro,
+		zend_object *error, bool transfer_error)
+{
+	zval args[2];
+	php_async_coroutine_arg(coro, &args[0]);
+
+	if (error != NULL) {
+		ZVAL_OBJ(&args[1], error);
+		if (!transfer_error) {
+			GC_ADDREF(error);
+		}
+	} else {
+		ZVAL_NULL(&args[1]);
+	}
+
+	const bool result = php_async_hook_call_bool(id, 2, args);
+
+	zval_ptr_dtor(&args[0]);
+	zval_ptr_dtor(&args[1]);
+	return result;
+}
+
+static bool php_async_thunk_resume(
+		zend_coroutine_t *coro, zend_object *error, const bool transfer_error)
+{
+	return php_async_thunk_wake(PHP_ASYNC_HOOK_RESUME, coro, error, transfer_error);
+}
+
+static bool php_async_thunk_cancel(
+		zend_coroutine_t *coro, zend_object *error, bool transfer_error, const bool is_safely)
+{
+	(void) is_safely; /* the PHP cancel hook takes no "safely" flag */
+	return php_async_thunk_wake(PHP_ASYNC_HOOK_CANCEL, coro, error, transfer_error);
+}
+
+/////////////////////////////////////////////////////////////////////
+/// Context thunks
+/////////////////////////////////////////////////////////////////////
+
+/* The context's PHP object as a zval, with a borrowed +1 for the call.
+ * The context is defined by external code and reached through
+ * context->object_offset. */
+static void php_async_context_arg(zend_async_context_t *context, zval *out)
+{
+	zend_object *object = ZEND_ASYNC_CONTEXT_OBJECT(context);
+
+	if (object != NULL) {
+		ZVAL_OBJ(out, object);
+		GC_ADDREF(object);
+	} else {
+		ZVAL_NULL(out);
+	}
+}
+
+static bool php_async_thunk_context_find(
+		zend_async_context_t *context, zval *key, zval *result, bool include_parent)
+{
+	zval args[3], retval;
+	php_async_context_arg(context, &args[0]);
+	ZVAL_COPY(&args[1], key);
+	ZVAL_BOOL(&args[2], include_parent);
+
+	const bool ok = php_async_hook_call(PHP_ASYNC_HOOK(PHP_ASYNC_HOOK_CONTEXT_FIND), 3, args, &retval);
+
+	if (result != NULL) {
+		if (ok) {
+			ZVAL_COPY(result, &retval);
+		} else {
+			ZVAL_NULL(result);
+		}
+	}
+
+	const bool found = ok && Z_TYPE(retval) != IS_NULL;
+
+	zval_ptr_dtor(&args[0]);
+	zval_ptr_dtor(&args[1]);
+	zval_ptr_dtor(&retval);
+	return found;
+}
+
+static bool php_async_thunk_context_set(zend_async_context_t *context, zval *key, zval *value)
+{
+	zval args[3];
+	php_async_context_arg(context, &args[0]);
+	ZVAL_COPY(&args[1], key);
+	ZVAL_COPY(&args[2], value);
+
+	const bool result = php_async_hook_call_bool(PHP_ASYNC_HOOK_CONTEXT_SET, 3, args);
+
+	zval_ptr_dtor(&args[0]);
+	zval_ptr_dtor(&args[1]);
+	zval_ptr_dtor(&args[2]);
+	return result;
+}
+
+static bool php_async_thunk_context_unset(zend_async_context_t *context, zval *key)
+{
+	zval args[2];
+	php_async_context_arg(context, &args[0]);
+	ZVAL_COPY(&args[1], key);
+
+	const bool result = php_async_hook_call_bool(PHP_ASYNC_HOOK_CONTEXT_UNSET, 2, args);
+
+	zval_ptr_dtor(&args[0]);
+	zval_ptr_dtor(&args[1]);
+	return result;
+}
+
+/////////////////////////////////////////////////////////////////////
+/// GC destructors thunk
+/////////////////////////////////////////////////////////////////////
+
+/* The engine's destructor executor as a PHP function. Deliberately NOT
+ * registered in any function table: the only way to reach it is the
+ * Closure the hook receives - application code cannot call it. */
+static ZEND_NAMED_FUNCTION(php_async_run_gc_destructors)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	RETURN_BOOL(zend_gc_run_pending_destructors());
+}
+
+static zend_internal_function php_async_gc_run_function;
+
+/* The hook receives a Closure over the engine's destructor executor.
+ * `run` is ignored at the PHP level: the Closure is the executor. */
+static bool php_async_thunk_gc_destructors(zend_async_gc_run_dtors_fn run)
+{
+	(void) run;
+
+	zval closure;
+	zend_create_closure(&closure, (zend_function *) &php_async_gc_run_function, NULL, NULL, NULL);
+
+	const bool result = php_async_hook_call_bool(PHP_ASYNC_HOOK_GC_DESTRUCTORS, 1, &closure);
+
+	zval_ptr_dtor(&closure);
+	return result;
+}
+
+/////////////////////////////////////////////////////////////////////
+/// Registration
+/////////////////////////////////////////////////////////////////////
+
+static void php_async_handlers_reset(void)
+{
+	for (php_async_hook_id id = 0; id < PHP_ASYNC_HOOK_COUNT; id++) {
+		php_async_hook_release(PHP_ASYNC_HOOK(id));
+	}
+
+	if (PHP_ASYNC_HANDLERS.module != NULL) {
+		zend_string_release(PHP_ASYNC_HANDLERS.module);
+		PHP_ASYNC_HANDLERS.module = NULL;
+	}
+
+	PHP_ASYNC_HANDLERS.active = false;
+}
+
+/* Fill `api` with the thunk pointers for the hooks that were provided. */
+static void php_async_build_api(zend_async_scheduler_api_t *api)
+{
+	memset(api, 0, sizeof(*api));
+	api->version = ZEND_ASYNC_API_VERSION_NUMBER;
+	api->size = sizeof(*api);
+
+	if (PHP_ASYNC_HOOK(PHP_ASYNC_HOOK_LAUNCH)->set) {
+		api->launch = php_async_thunk_launch;
+	}
+
+	if (PHP_ASYNC_HOOK(PHP_ASYNC_HOOK_SHUTDOWN)->set) {
+		api->shutdown = php_async_thunk_shutdown;
+	}
+
+	if (PHP_ASYNC_HOOK(PHP_ASYNC_HOOK_INTERCEPT_FIBER)->set) {
+		api->intercept_fiber = php_async_thunk_intercept_fiber;
+	}
+
+	if (PHP_ASYNC_HOOK(PHP_ASYNC_HOOK_ENQUEUE)->set) {
+		api->enqueue_coroutine = php_async_thunk_enqueue;
+	}
+
+	if (PHP_ASYNC_HOOK(PHP_ASYNC_HOOK_SUSPEND)->set) {
+		api->suspend = php_async_thunk_suspend;
+	}
+
+	if (PHP_ASYNC_HOOK(PHP_ASYNC_HOOK_RESUME)->set) {
+		api->resume = php_async_thunk_resume;
+	}
+
+	if (PHP_ASYNC_HOOK(PHP_ASYNC_HOOK_CANCEL)->set) {
+		api->cancel = php_async_thunk_cancel;
+	}
+
+	if (PHP_ASYNC_HOOK(PHP_ASYNC_HOOK_CONTEXT_FIND)->set) {
+		api->context_find = php_async_thunk_context_find;
+	}
+
+	if (PHP_ASYNC_HOOK(PHP_ASYNC_HOOK_CONTEXT_SET)->set) {
+		api->context_set = php_async_thunk_context_set;
+	}
+
+	if (PHP_ASYNC_HOOK(PHP_ASYNC_HOOK_CONTEXT_UNSET)->set) {
+		api->context_unset = php_async_thunk_context_unset;
+	}
+
+	if (PHP_ASYNC_HOOK(PHP_ASYNC_HOOK_GC_DESTRUCTORS)->set) {
+		api->gc_destructors = php_async_thunk_gc_destructors;
+	}
+
+	/* get_context / get_internal_context are not bridged: the slot must
+	 * return a zend_async_context_t*, which requires the context to be
+	 * embedded in the object — a C-extension concern, not pure PHP. */
+}
+
+ZEND_METHOD(Async_SchedulerHook, register)
+{
+	zend_string *module;
+	HashTable *hooks;
+
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_STR(module)
+		Z_PARAM_ARRAY_HT(hooks)
+	ZEND_PARSE_PARAMETERS_END();
+
+	/* A scheduler is registered once per process — by a C extension or by
+	 * PHP, whichever comes first. */
+	if (zend_async_is_enabled()) {
+		zend_throw_error(NULL, "A scheduler is already registered");
+		RETURN_THROWS();
+	}
+
+	for (php_async_hook_id id = 0; id < PHP_ASYNC_HOOK_COUNT; id++) {
+		if (!php_async_hook_take(hooks, id)) {
+			php_async_handlers_reset();
+			RETURN_THROWS();
+		}
+	}
+
+	PHP_ASYNC_HANDLERS.module = zend_string_copy(module);
+	PHP_ASYNC_HANDLERS.active = true;
+
+	zend_async_scheduler_api_t api;
+	php_async_build_api(&api);
+
+	if (!zend_async_scheduler_register(ZSTR_VAL(module), &api)) {
+		php_async_handlers_reset();
+		RETURN_FALSE;
+	}
+
+	/* The engine's own launch point runs before userland code; a PHP
+	 * scheduler therefore launches immediately at registration. */
+	ZEND_ASYNC_INITIALIZE;
+
+	if (PHP_ASYNC_HOOK(PHP_ASYNC_HOOK_LAUNCH)->set) {
+		ZEND_ASYNC_SCHEDULER_LAUNCH();
+	}
+
+	ZEND_ASYNC_ACTIVATE;
+
+	RETURN_TRUE;
+}
+
+ZEND_METHOD(Async_SchedulerHook, getModule)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	const char *module = zend_async_get_scheduler_module();
+
+	if (module == NULL) {
+		RETURN_NULL();
+	}
+
+	RETURN_STRING(module);
+}
+
+ZEND_METHOD(Async_SchedulerHook, defer)
+{
+	zval *task;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ZVAL(task)
+	ZEND_PARSE_PARAMETERS_END();
+
+	/* The queue is the provider's: forward the callable to its DEFER hook. */
+	if (!PHP_ASYNC_HOOK(PHP_ASYNC_HOOK_DEFER)->set) {
+		zend_throw_error(NULL, "The registered scheduler provides no defer hook");
+		RETURN_THROWS();
+	}
+
+	zval arg;
+	ZVAL_COPY(&arg, task);
+	php_async_hook_call_bool(PHP_ASYNC_HOOK_DEFER, 1, &arg);
+	zval_ptr_dtor(&arg);
+
+	if (UNEXPECTED(EG(exception))) {
+		RETURN_THROWS();
+	}
+}
+
+void zend_register_scheduler_hook(void)
+{
+	register_class_Async_SchedulerHook();
+
+	php_async_gc_run_function.type = ZEND_INTERNAL_FUNCTION;
+	php_async_gc_run_function.function_name =
+			zend_string_init_interned(ZEND_STRL("Async\\SchedulerHook::gcDestructorsRun"), true);
+	php_async_gc_run_function.handler = php_async_run_gc_destructors;
+}
+
+void zend_scheduler_hook_request_shutdown(void)
+{
+	if (PHP_ASYNC_HANDLERS.active) {
+		php_async_handlers_reset();
+	}
+}

--- a/Zend/zend_scheduler_hook.h
+++ b/Zend/zend_scheduler_hook.h
@@ -1,0 +1,31 @@
+/*
+   +----------------------------------------------------------------------+
+   | Copyright © The PHP Group and Contributors.                          |
+   +----------------------------------------------------------------------+
+   | This source file is subject to the Modified BSD License that is      |
+   | bundled with this package in the file LICENSE, and is available      |
+   | through the World Wide Web at <https://www.php.net/license/>.        |
+   |                                                                      |
+   | SPDX-License-Identifier: BSD-3-Clause                                |
+   +----------------------------------------------------------------------+
+   | Authors: Edmond <edmondifthen@proton.me>                             |
+   +----------------------------------------------------------------------+
+*/
+#ifndef ZEND_SCHEDULER_HOOK_H
+#define ZEND_SCHEDULER_HOOK_H
+
+#include "zend.h"
+
+BEGIN_EXTERN_C()
+
+/* Registers the async_scheduler_register() userland function. Called once
+ * from the engine startup. */
+void zend_register_scheduler_hook(void);
+
+/* Releases the PHP scheduler handlers held for the current request. Called
+ * from request shutdown; a no-op when no PHP scheduler was registered. */
+void zend_scheduler_hook_request_shutdown(void);
+
+END_EXTERN_C()
+
+#endif /* ZEND_SCHEDULER_HOOK_H */

--- a/Zend/zend_scheduler_hook.stub.php
+++ b/Zend/zend_scheduler_hook.stub.php
@@ -1,0 +1,49 @@
+<?php
+
+/** @generate-class-entries */
+
+namespace Async;
+
+/**
+ * Activation point for the concurrent mode.
+ *
+ * A scheduler is registered by handing register() a map of hook name
+ * (the class constants below) to callable. There is exactly one scheduler
+ * per process, so the class is used only through its static methods.
+ */
+final class SchedulerHook
+{
+    public const string LAUNCH = 'launch';
+    public const string SHUTDOWN = 'shutdown';
+    public const string INTERCEPT_FIBER = 'intercept_fiber';
+    public const string ENQUEUE = 'enqueue_coroutine';
+    public const string SUSPEND = 'suspend';
+    public const string RESUME = 'resume';
+    public const string CANCEL = 'cancel';
+    public const string CONTEXT_FIND = 'context_find';
+    public const string CONTEXT_SET = 'context_set';
+    public const string CONTEXT_UNSET = 'context_unset';
+    public const string GC_DESTRUCTORS = 'gc_destructors';
+    public const string DEFER = 'defer';
+
+    /**
+     * Registers a scheduler and activates the concurrent mode.
+     *
+     * $hooks maps a hook constant to a callable; omitted hooks keep their
+     * defaults. A scheduler is registered once per process: calling this
+     * when a scheduler is already registered (by a C extension or by an
+     * earlier PHP call) throws an Error.
+     */
+    public static function register(string $module, array $hooks): bool {}
+
+    /** Returns the module name of the registered scheduler, or null when none. */
+    public static function getModule(): ?string {}
+
+    /**
+     * Queues a callable on the scheduler's microtask queue (one-shot,
+     * runs on the next tick). Forwards to the DEFER hook; the queue and
+     * its draining belong to the scheduler.
+     */
+    public static function defer(callable $task): void {}
+
+}

--- a/Zend/zend_scheduler_hook_arginfo.h
+++ b/Zend/zend_scheduler_hook_arginfo.h
@@ -1,0 +1,119 @@
+/* This is a generated file, edit zend_scheduler_hook.stub.php instead.
+ * Stub hash: 06651f905db71f840fb874392eb3edf6709a87c7 */
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Async_SchedulerHook_register, 0, 2, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, module, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, hooks, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Async_SchedulerHook_getModule, 0, 0, IS_STRING, 1)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Async_SchedulerHook_defer, 0, 1, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, task, IS_CALLABLE, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_METHOD(Async_SchedulerHook, register);
+ZEND_METHOD(Async_SchedulerHook, getModule);
+ZEND_METHOD(Async_SchedulerHook, defer);
+
+static const zend_function_entry class_Async_SchedulerHook_methods[] = {
+	ZEND_ME(Async_SchedulerHook, register, arginfo_class_Async_SchedulerHook_register, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	ZEND_ME(Async_SchedulerHook, getModule, arginfo_class_Async_SchedulerHook_getModule, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	ZEND_ME(Async_SchedulerHook, defer, arginfo_class_Async_SchedulerHook_defer, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	ZEND_FE_END
+};
+
+static zend_class_entry *register_class_Async_SchedulerHook(void)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "Async", "SchedulerHook", class_Async_SchedulerHook_methods);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL);
+
+	zval const_LAUNCH_value;
+	zend_string *const_LAUNCH_value_str = zend_string_init("launch", strlen("launch"), 1);
+	ZVAL_STR(&const_LAUNCH_value, const_LAUNCH_value_str);
+	zend_string *const_LAUNCH_name = zend_string_init_interned("LAUNCH", sizeof("LAUNCH") - 1, true);
+	zend_declare_typed_class_constant(class_entry, const_LAUNCH_name, &const_LAUNCH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release_ex(const_LAUNCH_name, true);
+
+	zval const_SHUTDOWN_value;
+	zend_string *const_SHUTDOWN_value_str = zend_string_init("shutdown", strlen("shutdown"), 1);
+	ZVAL_STR(&const_SHUTDOWN_value, const_SHUTDOWN_value_str);
+	zend_string *const_SHUTDOWN_name = zend_string_init_interned("SHUTDOWN", sizeof("SHUTDOWN") - 1, true);
+	zend_declare_typed_class_constant(class_entry, const_SHUTDOWN_name, &const_SHUTDOWN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release_ex(const_SHUTDOWN_name, true);
+
+	zval const_INTERCEPT_FIBER_value;
+	zend_string *const_INTERCEPT_FIBER_value_str = zend_string_init("intercept_fiber", strlen("intercept_fiber"), 1);
+	ZVAL_STR(&const_INTERCEPT_FIBER_value, const_INTERCEPT_FIBER_value_str);
+	zend_string *const_INTERCEPT_FIBER_name = zend_string_init_interned("INTERCEPT_FIBER", sizeof("INTERCEPT_FIBER") - 1, true);
+	zend_declare_typed_class_constant(class_entry, const_INTERCEPT_FIBER_name, &const_INTERCEPT_FIBER_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release_ex(const_INTERCEPT_FIBER_name, true);
+
+	zval const_ENQUEUE_value;
+	zend_string *const_ENQUEUE_value_str = zend_string_init("enqueue_coroutine", strlen("enqueue_coroutine"), 1);
+	ZVAL_STR(&const_ENQUEUE_value, const_ENQUEUE_value_str);
+	zend_string *const_ENQUEUE_name = zend_string_init_interned("ENQUEUE", sizeof("ENQUEUE") - 1, true);
+	zend_declare_typed_class_constant(class_entry, const_ENQUEUE_name, &const_ENQUEUE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release_ex(const_ENQUEUE_name, true);
+
+	zval const_SUSPEND_value;
+	zend_string *const_SUSPEND_value_str = zend_string_init("suspend", strlen("suspend"), 1);
+	ZVAL_STR(&const_SUSPEND_value, const_SUSPEND_value_str);
+	zend_string *const_SUSPEND_name = zend_string_init_interned("SUSPEND", sizeof("SUSPEND") - 1, true);
+	zend_declare_typed_class_constant(class_entry, const_SUSPEND_name, &const_SUSPEND_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release_ex(const_SUSPEND_name, true);
+
+	zval const_RESUME_value;
+	zend_string *const_RESUME_value_str = zend_string_init("resume", strlen("resume"), 1);
+	ZVAL_STR(&const_RESUME_value, const_RESUME_value_str);
+	zend_string *const_RESUME_name = zend_string_init_interned("RESUME", sizeof("RESUME") - 1, true);
+	zend_declare_typed_class_constant(class_entry, const_RESUME_name, &const_RESUME_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release_ex(const_RESUME_name, true);
+
+	zval const_CANCEL_value;
+	zend_string *const_CANCEL_value_str = zend_string_init("cancel", strlen("cancel"), 1);
+	ZVAL_STR(&const_CANCEL_value, const_CANCEL_value_str);
+	zend_string *const_CANCEL_name = zend_string_init_interned("CANCEL", sizeof("CANCEL") - 1, true);
+	zend_declare_typed_class_constant(class_entry, const_CANCEL_name, &const_CANCEL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release_ex(const_CANCEL_name, true);
+
+	zval const_CONTEXT_FIND_value;
+	zend_string *const_CONTEXT_FIND_value_str = zend_string_init("context_find", strlen("context_find"), 1);
+	ZVAL_STR(&const_CONTEXT_FIND_value, const_CONTEXT_FIND_value_str);
+	zend_string *const_CONTEXT_FIND_name = zend_string_init_interned("CONTEXT_FIND", sizeof("CONTEXT_FIND") - 1, true);
+	zend_declare_typed_class_constant(class_entry, const_CONTEXT_FIND_name, &const_CONTEXT_FIND_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release_ex(const_CONTEXT_FIND_name, true);
+
+	zval const_CONTEXT_SET_value;
+	zend_string *const_CONTEXT_SET_value_str = zend_string_init("context_set", strlen("context_set"), 1);
+	ZVAL_STR(&const_CONTEXT_SET_value, const_CONTEXT_SET_value_str);
+	zend_string *const_CONTEXT_SET_name = zend_string_init_interned("CONTEXT_SET", sizeof("CONTEXT_SET") - 1, true);
+	zend_declare_typed_class_constant(class_entry, const_CONTEXT_SET_name, &const_CONTEXT_SET_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release_ex(const_CONTEXT_SET_name, true);
+
+	zval const_CONTEXT_UNSET_value;
+	zend_string *const_CONTEXT_UNSET_value_str = zend_string_init("context_unset", strlen("context_unset"), 1);
+	ZVAL_STR(&const_CONTEXT_UNSET_value, const_CONTEXT_UNSET_value_str);
+	zend_string *const_CONTEXT_UNSET_name = zend_string_init_interned("CONTEXT_UNSET", sizeof("CONTEXT_UNSET") - 1, true);
+	zend_declare_typed_class_constant(class_entry, const_CONTEXT_UNSET_name, &const_CONTEXT_UNSET_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release_ex(const_CONTEXT_UNSET_name, true);
+
+	zval const_GC_DESTRUCTORS_value;
+	zend_string *const_GC_DESTRUCTORS_value_str = zend_string_init("gc_destructors", strlen("gc_destructors"), 1);
+	ZVAL_STR(&const_GC_DESTRUCTORS_value, const_GC_DESTRUCTORS_value_str);
+	zend_string *const_GC_DESTRUCTORS_name = zend_string_init_interned("GC_DESTRUCTORS", sizeof("GC_DESTRUCTORS") - 1, true);
+	zend_declare_typed_class_constant(class_entry, const_GC_DESTRUCTORS_name, &const_GC_DESTRUCTORS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release_ex(const_GC_DESTRUCTORS_name, true);
+
+	zval const_DEFER_value;
+	zend_string *const_DEFER_value_str = zend_string_init("defer", strlen("defer"), 1);
+	ZVAL_STR(&const_DEFER_value, const_DEFER_value_str);
+	zend_string *const_DEFER_name = zend_string_init_interned("DEFER", sizeof("DEFER") - 1, true);
+	zend_declare_typed_class_constant(class_entry, const_DEFER_name, &const_DEFER_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release_ex(const_DEFER_name, true);
+
+	return class_entry;
+}

--- a/configure.ac
+++ b/configure.ac
@@ -1752,6 +1752,8 @@ PHP_ADD_SOURCES([Zend], m4_normalize([
     zend_call_stack.c
     zend_closures.c
     zend_compile.c
+    zend_async_API.c
+    zend_scheduler_hook.c
     zend_constants.c
     zend_cpuinfo.c
     zend_default_classes.c

--- a/main/main.c
+++ b/main/main.c
@@ -87,6 +87,8 @@
 #include "SAPI.h"
 #include "rfc1867.h"
 
+#include "zend_async_API.h"
+
 #include "main_arginfo.h"
 /* }}} */
 
@@ -1992,6 +1994,13 @@ void php_request_shutdown(void *dummy)
 		zend_call_destructors();
 	} zend_end_try();
 
+	/* Before PHP shuts down completely, control is passed to the
+	 * remaining coroutines one last time (if any). */
+	zend_try {
+		ZEND_ASYNC_RUN_SCHEDULER_AFTER_MAIN(false);
+	} zend_end_try();
+	ZEND_ASYNC_DEACTIVATE;
+
 	/* 3. Flush all output buffers */
 	zend_try {
 		php_output_end_all();
@@ -2648,6 +2657,13 @@ PHPAPI bool php_execute_script_ex(zend_file_handle *primary_file, zval *retval)
 			zend_set_timeout(zend_ini_long_literal("max_execution_time"), false);
 		}
 
+		/* The scheduler is not lazy: it always starts right before the
+		 * script code runs. A no-op until a scheduler module has
+		 * registered itself. */
+		if (ZEND_ASYNC_IS_READY) {
+			ZEND_ASYNC_SCHEDULER_LAUNCH();
+		}
+
 		if (prepend_file_p && result) {
 			result = zend_execute_script(ZEND_REQUIRE, NULL, prepend_file_p) == SUCCESS;
 		}
@@ -2657,7 +2673,11 @@ PHPAPI bool php_execute_script_ex(zend_file_handle *primary_file, zval *retval)
 		if (append_file_p && result) {
 			result = zend_execute_script(ZEND_REQUIRE, NULL, append_file_p) == SUCCESS;
 		}
+
+		ZEND_ASYNC_RUN_SCHEDULER_AFTER_MAIN(false);
 	} zend_catch {
+		/* Give the scheduler a chance to handle a bailout in the main flow. */
+		ZEND_ASYNC_RUN_SCHEDULER_AFTER_MAIN(true);
 		result = false;
 	} zend_end_try();
 

--- a/sapi/phpdbg/phpdbg_prompt.c
+++ b/sapi/phpdbg/phpdbg_prompt.c
@@ -18,6 +18,7 @@
 #include <string.h>
 #include "zend.h"
 #include "zend_compile.h"
+#include "zend_async_API.h"
 #include "zend_exceptions.h"
 #include "zend_vm.h"
 #include "zend_generators.h"
@@ -857,7 +858,11 @@ free_cmd:
 		zend_try {
 			PHPDBG_G(flags) ^= PHPDBG_IS_INTERACTIVE;
 			PHPDBG_G(flags) |= PHPDBG_IS_RUNNING;
+			if (ZEND_ASYNC_IS_READY) {
+				ZEND_ASYNC_SCHEDULER_LAUNCH();
+			}
 			zend_execute(PHPDBG_G(ops), &PHPDBG_G(retval));
+			ZEND_ASYNC_RUN_SCHEDULER_AFTER_MAIN(false);
 			PHPDBG_G(flags) ^= PHPDBG_IS_INTERACTIVE;
 		} zend_catch {
 			PHPDBG_G(in_execution) = 0;

--- a/win32/build/config.w32
+++ b/win32/build/config.w32
@@ -241,7 +241,7 @@ ADD_SOURCES("Zend", "zend_language_parser.c zend_language_scanner.c \
 	zend_float.c zend_string.c zend_generators.c zend_virtual_cwd.c zend_ast.c \
 	zend_inheritance.c zend_smart_str.c zend_cpuinfo.c zend_observer.c zend_system_id.c \
 	zend_enum.c zend_fibers.c zend_atomic.c zend_hrtime.c zend_frameless_function.c zend_property_hooks.c \
-	zend_lazy_objects.c zend_autoload.c");
+	zend_lazy_objects.c zend_autoload.c zend_async_API.c zend_scheduler_hook.c");
 ADD_SOURCES("Zend\\Optimizer", "zend_optimizer.c pass1.c pass3.c optimize_func_calls.c block_pass.c optimize_temp_vars_5.c nop_removal.c compact_literals.c zend_cfg.c zend_dfg.c dfa_pass.c zend_ssa.c zend_inference.c zend_func_info.c zend_call_graph.c zend_dump.c escape_analysis.c compact_vars.c dce.c sccp.c scdf.c");
 
 var PHP_ASSEMBLER = PATH_PROG({


### PR DESCRIPTION
The engine gains the ability to activate a concurrent execution mode: a scheduler (a C extension or a PHP library) registers a set of hooks through a single call and takes control of concurrency. The core contains no implementation — no scheduler, no queues, no event system; it is hook routing plus the minimal mechanism only the engine can perform.

RFC: https://github.com/true-async/php-async-core-rfc/blob/main/RFC.md
Integration reference: https://github.com/true-async/php-async-core-rfc/blob/main/SCHEDULER.md

Tested: Zend/tests/async (13 tests) plus the full fibers and gc suites — 194/194.