### PR TITLE
#200: fix double-release and use-after-free of pooled PDO connections

### DIFF
--- a/ext/pdo/pdo_pool.c
+++ b/ext/pdo/pdo_pool.c
@@ -30,23 +30,32 @@ void pdo_pool_shutdown(void)
 {
 }
 
-/* Get a stable hash key for the current coroutine.
- * Prefers zend_object handle (sequential uint32_t) when available,
- * falls back to pointer address for internal coroutines. */
-static zend_always_inline zend_ulong pdo_pool_coro_key(zend_coroutine_t *coro)
+/* Stable hash key for the current execution context. Main flow maps to 0
+ * either way: the scheduler launch promotes it into the main coroutine, so
+ * any coroutine-derived key would change mid-execution. Handle 0 is reserved
+ * by the objects store, so no other coroutine can collide with it. */
+static zend_always_inline zend_ulong pdo_pool_current_key(void)
 {
+	zend_coroutine_t *coro = ZEND_ASYNC_CURRENT_COROUTINE;
+
+	if (coro == NULL || ZEND_COROUTINE_IS_MAIN(coro)) {
+		return 0;
+	}
+
 	if (ZEND_ASYNC_EVENT_IS_ZEND_OBJ(&coro->event)) {
 		return (zend_ulong)ZEND_ASYNC_EVENT_TO_OBJECT(&coro->event)->handle;
 	}
+
 	return ((uintptr_t)coro) >> ZEND_MM_ALIGNMENT_LOG2;
 }
 
 /*
- * Binding: long-lived association between a pool and a coroutine.
- * Created once on first acquire, reused for all subsequent acquire/release
- * cycles within the same coroutine. Freed when the coroutine finalizes.
+ * Binding: long-lived association between a pool and one execution context
+ * (a coroutine, or the main flow under key 0). Created on first acquire and
+ * reused for every later acquire/release in that context. Freed when the
+ * coroutine finalizes, or at pool destroy for the main flow.
  */
-typedef struct {
+struct _pdo_pool_binding {
 	zend_async_event_callback_t event;  /* Must be first for event callback cast */
 	pdo_dbh_t *dbh;                     /* master PDO handle that owns the pool, NULL if pool destroyed */
 	pdo_dbh_t *conn;                    /* active connection, NULL if released back to pool */
@@ -57,7 +66,7 @@ typedef struct {
 	zend_object *last_failed_query_stmt_obj;
 
 	pdo_error_type error_code;
-} pdo_pool_binding_t;
+};
 
 static void pdo_pool_binding_release_query_stmt(pdo_pool_binding_t *binding)
 {
@@ -74,12 +83,37 @@ static pdo_pool_binding_t *pdo_pool_current_binding(pdo_dbh_t *dbh)
 		return NULL;
 	}
 
-	zend_coroutine_t *coro = ZEND_ASYNC_CURRENT_COROUTINE;
-	if (coro == NULL) {
-		return NULL;
-	}
+	return zend_hash_index_find_ptr(dbh->pool_bindings, pdo_pool_current_key());
+}
 
-	return zend_hash_index_find_ptr(dbh->pool_bindings, pdo_pool_coro_key(coro));
+/* Break the ownership link between a pooled conn and its binding.
+ * Must run before either side is freed or handed to someone else. */
+static zend_always_inline void pdo_pool_detach_conn(pdo_dbh_t *conn)
+{
+	if (conn->owner_binding != NULL) {
+		conn->owner_binding->conn = NULL;
+		conn->owner_binding = NULL;
+	}
+}
+
+/* Return a pooled conn to the pool exactly once. Detaching first is what makes
+ * this safe: the binding key can drift between acquire and release, so a
+ * key-based lookup alone cannot be trusted to find the current owner. */
+static void pdo_pool_release_conn(pdo_dbh_t *conn)
+{
+	zend_async_pool_t *pool = conn->pool;
+
+	/* Releasing into a closed pool destroys the conn, which drops the slot's
+	 * own pool reference — hold one here so the pool survives the call. */
+	ZEND_ASYNC_EVENT_ADD_REF(&pool->event);
+
+	pdo_pool_detach_conn(conn);
+
+	zval conn_zval;
+	ZVAL_PTR(&conn_zval, conn);
+	ZEND_ASYNC_POOL_RELEASE(pool, &conn_zval);
+
+	ZEND_ASYNC_EVENT_RELEASE(&pool->event);
 }
 
 PDO_API pdo_stmt_t *pdo_dbh_get_last_failed_query_stmt(pdo_dbh_t *dbh)
@@ -160,6 +194,12 @@ static void pdo_pool_free_conn(pdo_dbh_t *conn)
 		conn->methods->closer(conn);
 	}
 
+	/* Drop the slot's reference on the pool (taken in pdo_pool_factory) */
+	if (conn->pool != NULL) {
+		ZEND_ASYNC_EVENT_RELEASE(&conn->pool->event);
+		conn->pool = NULL;
+	}
+
 	if (conn->data_source) {
 		efree((char *)conn->data_source);
 	}
@@ -200,8 +240,11 @@ static bool pdo_pool_factory(zend_async_pool_t *pool, zval *result)
 
 	/* Expose owning pool to driver factory so it can recognize pool-slot
 	 * context and reach the template via pool->user_data. Drivers that need
-	 * per-template auxiliary state (e.g. SQLite UDF registry) read it here. */
+	 * per-template auxiliary state (e.g. SQLite UDF registry) read it here.
+	 * The slot keeps a reference so statements can release through it even
+	 * after the PDO handle is gone; released in pdo_pool_free_conn. */
 	conn->pool = pool;
+	ZEND_ASYNC_EVENT_ADD_REF(&pool->event);
 
 	/* Call driver factory to create actual connection */
 	if (UNEXPECTED(!dbh->driver->db_handle_factory(conn, NULL))) {
@@ -226,6 +269,9 @@ static void pdo_pool_destructor(zend_async_pool_t *pool, zval *resource)
 	if (UNEXPECTED(conn == NULL)) {
 		return;
 	}
+
+	/* Drop any binding still pointing here so it cannot reach freed memory */
+	pdo_pool_detach_conn(conn);
 
 	pdo_pool_free_conn(conn);
 }
@@ -328,13 +374,14 @@ static void pdo_pool_binding_on_coroutine_finish(
 
 	pdo_pool_binding_release_query_stmt(binding);
 
-	/* Release conn only when no stmt still references it; stmts' destructors
-	 * release it themselves otherwise (last stmt to free does it). */
-	if (binding->conn != NULL && binding->conn->pool_slot_refcount == 0) {
-		zval conn_zval;
-		ZVAL_PTR(&conn_zval, binding->conn);
-		ZEND_ASYNC_POOL_RELEASE(binding->dbh->pool, &conn_zval);
-		binding->conn = NULL;
+	/* Either way the conn must stop pointing here: the framework efrees this
+	 * binding via dispose() as soon as this callback returns. */
+	if (binding->conn != NULL) {
+		if (binding->conn->pool_slot_refcount == 0) {
+			pdo_pool_release_conn(binding->conn);
+		} else {
+			pdo_pool_detach_conn(binding->conn);
+		}
 	}
 
 	/* Remove binding from pool_bindings */
@@ -532,10 +579,11 @@ void pdo_pool_destroy(pdo_dbh_t *dbh)
 			 * safer than force-release (UAF). */
 			if (binding->conn != NULL && dbh->pool != NULL
 				&& binding->conn->pool_slot_refcount == 0) {
-				zval conn_zval;
-				ZVAL_PTR(&conn_zval, binding->conn);
-				ZEND_ASYNC_POOL_RELEASE(dbh->pool, &conn_zval);
-				binding->conn = NULL;
+				pdo_pool_release_conn(binding->conn);
+			} else if (binding->conn != NULL) {
+				/* Kept alive by statements — drop the back-pointer, this
+				 * binding is freed (here or via dispose) before they are. */
+				pdo_pool_detach_conn(binding->conn);
 			}
 
 			if (!binding->has_coro_callback) {
@@ -558,7 +606,7 @@ void pdo_pool_destroy(pdo_dbh_t *dbh)
 		dbh->pool_wrapper = NULL;
 	}
 
-	/* Step 4: Close and dispose the pool via event lifecycle */
+	/* Step 3: Close and dispose the pool via event lifecycle */
 	if (dbh->pool) {
 		ZEND_ASYNC_POOL_CLOSE(dbh->pool);
 		ZEND_ASYNC_EVENT_RELEASE(&dbh->pool->event);
@@ -573,14 +621,11 @@ void pdo_pool_destroy(pdo_dbh_t *dbh)
  */
 pdo_dbh_t *pdo_pool_peek_conn(pdo_dbh_t *dbh)
 {
-	zend_coroutine_t *coro = ZEND_ASYNC_CURRENT_COROUTINE;
-	const zend_ulong coro_key = coro ? pdo_pool_coro_key(coro) : 0;
-
 	if (dbh->pool == NULL) {
 		return dbh;
 	}
 
-	const pdo_pool_binding_t *binding = zend_hash_index_find_ptr(dbh->pool_bindings, coro_key);
+	const pdo_pool_binding_t *binding = zend_hash_index_find_ptr(dbh->pool_bindings, pdo_pool_current_key());
 	if (binding != NULL && binding->conn != NULL) {
 		return binding->conn;
 	}
@@ -595,7 +640,7 @@ pdo_dbh_t *pdo_pool_peek_conn(pdo_dbh_t *dbh)
 pdo_dbh_t *pdo_pool_acquire_conn(pdo_dbh_t *dbh)
 {
 	zend_coroutine_t *coro = ZEND_ASYNC_CURRENT_COROUTINE;
-	const zend_ulong coro_key = coro ? pdo_pool_coro_key(coro) : 0;
+	const zend_ulong coro_key = pdo_pool_current_key();
 
 	if (dbh->pool == NULL) {
 		return dbh;
@@ -604,23 +649,26 @@ pdo_dbh_t *pdo_pool_acquire_conn(pdo_dbh_t *dbh)
 	/* Check existing binding */
 	pdo_pool_binding_t *binding = zend_hash_index_find_ptr(dbh->pool_bindings, coro_key);
 	if (binding != NULL) {
+		/* Created before the scheduler launched, so it never got a callback;
+		 * the main coroutine exists now, so attach to its finalize. */
+		if (!binding->has_coro_callback && coro != NULL) {
+			coro->event.add_callback(&coro->event, &binding->event);
+			binding->has_coro_callback = true;
+		}
+
 		/* Binding exists — reuse active connection or acquire a new one */
 		if (EXPECTED(binding->conn != NULL)) {
 			if (EXPECTED(false == binding->conn->conn_broken)) {
 				return binding->conn;
 			}
 
-			/* Broken: detach. If stmts still hold conn via pooled_conn,
-			 * last stmt's free will release it; otherwise release now. */
-			pdo_pool_binding_release_query_stmt(binding);
-
+			/* Broken: detach so the binding can take a fresh conn below.
+			 * If stmts still hold it, the last stmt's free releases it. */
 			pdo_dbh_t *old_conn = binding->conn;
-			binding->conn = NULL;
+			pdo_pool_detach_conn(old_conn);
 
 			if (old_conn->pool_slot_refcount == 0) {
-				zval cz;
-				ZVAL_PTR(&cz, old_conn);
-				ZEND_ASYNC_POOL_RELEASE(dbh->pool, &cz);
+				pdo_pool_release_conn(old_conn);
 			}
 		}
 
@@ -633,10 +681,12 @@ pdo_dbh_t *pdo_pool_acquire_conn(pdo_dbh_t *dbh)
 		}
 
 		binding->conn = Z_PTR(resource);
+		binding->conn->owner_binding = binding;
+
 		return binding->conn;
 	}
 
-	/* First acquire for this coroutine — create binding */
+	/* First acquire for this context — create binding */
 	zval resource;
 	if (UNEXPECTED(!ZEND_ASYNC_POOL_ACQUIRE(dbh->pool, &resource, 0))) {
 		return NULL;
@@ -648,12 +698,14 @@ pdo_dbh_t *pdo_pool_acquire_conn(pdo_dbh_t *dbh)
 	binding->event.ref_count = 1;
 	binding->dbh = dbh;
 	binding->conn = Z_PTR(resource);
+	binding->conn->owner_binding = binding;
 	binding->coro_key = coro_key;
 	memcpy(binding->error_code, PDO_ERR_NONE, sizeof(pdo_error_type));
 
 	zend_hash_index_add_new_ptr(dbh->pool_bindings, coro_key, binding);
 
-	/* Register callback on coroutine — once, never removed */
+	/* Register callback on coroutine — once, never removed.
+	 * NULL before the scheduler launches; the reuse path attaches it later. */
 	if (coro != NULL) {
 		coro->event.add_callback(&coro->event, &binding->event);
 		binding->has_coro_callback = true;
@@ -668,14 +720,11 @@ pdo_dbh_t *pdo_pool_acquire_conn(pdo_dbh_t *dbh)
  */
 void pdo_pool_maybe_release(pdo_dbh_t *dbh)
 {
-	zend_coroutine_t *coro = ZEND_ASYNC_CURRENT_COROUTINE;
-	const zend_ulong coro_key = coro ? pdo_pool_coro_key(coro) : 0;
-
 	if (dbh->pool == NULL || dbh->pool_bindings == NULL) {
 		return;
 	}
 
-	pdo_pool_binding_t *binding = zend_hash_index_find_ptr(dbh->pool_bindings, coro_key);
+	pdo_pool_binding_t *binding = zend_hash_index_find_ptr(dbh->pool_bindings, pdo_pool_current_key());
 	if (binding == NULL || binding->conn == NULL) {
 		return;
 	}
@@ -684,10 +733,24 @@ void pdo_pool_maybe_release(pdo_dbh_t *dbh)
 		return;
 	}
 
-	zval conn_zval;
-	ZVAL_PTR(&conn_zval, binding->conn);
-	ZEND_ASYNC_POOL_RELEASE(dbh->pool, &conn_zval);
-	binding->conn = NULL;
+	pdo_pool_release_conn(binding->conn);
+}
+
+/* Return a statement's borrowed conn to the pool once the last statement lets
+ * go of it. Used instead of a key-based lookup because the statement may be
+ * destroyed in a different context than the one that acquired the conn. */
+void pdo_pool_release_stmt_conn(pdo_dbh_t *conn)
+{
+	/* An owning binding releases the conn itself once the txn ends. With no
+	 * owner left this statement was the last holder, so release now and let
+	 * the pool's before_release roll the transaction back. */
+	if (conn->in_txn && conn->owner_binding != NULL) {
+		return;
+	}
+
+	/* Goes through conn->pool, never stmt->dbh: the PDO handle may already be
+	 * freed (GC order). Releasing into a closed pool destroys the conn. */
+	pdo_pool_release_conn(conn);
 }
 
 /* Get PHP Pool wrapper object for getPool() method */

--- a/ext/pdo/pdo_pool.h
+++ b/ext/pdo/pdo_pool.h
@@ -60,6 +60,10 @@ pdo_dbh_t *pdo_pool_peek_conn(pdo_dbh_t *dbh);
  */
 void pdo_pool_maybe_release(pdo_dbh_t *dbh);
 
+/* Release a conn borrowed by a statement back to the pool. Reaches the pool
+ * through the conn itself, so it is safe when stmt->dbh is already freed. */
+void pdo_pool_release_stmt_conn(pdo_dbh_t *conn);
+
 PDO_API pdo_stmt_t *pdo_dbh_get_last_failed_query_stmt(pdo_dbh_t *dbh);
 PDO_API void pdo_dbh_set_last_failed_query_stmt(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zend_object *obj);
 PDO_API void pdo_dbh_release_last_failed_query_stmt(pdo_dbh_t *dbh);

--- a/ext/pdo/pdo_stmt.c
+++ b/ext/pdo/pdo_stmt.c
@@ -2040,15 +2040,7 @@ PDO_API void php_pdo_free_statement(pdo_stmt_t *stmt)
 		pconn->pool_slot_refcount--;
 
 		if (pconn->pool_slot_refcount == 0) {
-			if (pdo_pool_peek_conn(stmt->dbh) == pconn) {
-				pdo_pool_maybe_release(stmt->dbh);
-			} else {
-				/* Orphaned conn (binding switched away or coroutine ended) —
-				 * release directly; pool destroys it if broken. */
-				zval conn_zval;
-				ZVAL_PTR(&conn_zval, pconn);
-				ZEND_ASYNC_POOL_RELEASE(stmt->dbh->pool, &conn_zval);
-			}
+			pdo_pool_release_stmt_conn(pconn);
 		}
 
 		stmt->pooled_conn = NULL;

--- a/ext/pdo/php_pdo_driver.h
+++ b/ext/pdo/php_pdo_driver.h
@@ -28,6 +28,9 @@ struct pdo_bound_param_data;
 /* forward declaration for async pool (from zend_async_API.h) */
 typedef struct _zend_async_pool_s zend_async_pool_t;
 
+/* forward declaration for the per-coroutine pool binding (private to pdo_pool.c) */
+typedef struct _pdo_pool_binding pdo_pool_binding_t;
+
 #ifndef TRUE
 # define TRUE 1
 #endif
@@ -35,7 +38,7 @@ typedef struct _zend_async_pool_s zend_async_pool_t;
 # define FALSE 0
 #endif
 
-#define PDO_DRIVER_API	20260205
+#define PDO_DRIVER_API	20260722
 
 /* Doctrine hardcodes these constants, avoid changing their values. */
 enum pdo_param_type {
@@ -531,8 +534,9 @@ struct _pdo_dbh_t {
 
 	/* Connection pool (requires async extension) */
 	zend_async_pool_t *pool;		/* internal pool, NULL if pooling disabled */
-	HashTable *pool_bindings;	/* coroutine_id => pdo_pool_binding_t* */
+	HashTable *pool_bindings;	/* execution context key => pdo_pool_binding_t*, main flow is 0 */
 	zend_object *pool_wrapper;		/* cached PHP Async\Pool object for getPool() */
+	pdo_pool_binding_t *owner_binding;	/* binding holding this slot; NULL when unowned (idle, or stmt-held orphan) */
 	uint32_t pool_slot_refcount;	/* number of statements borrowing this pooled connection */
 	uint32_t pool_stmt_cache_size;	/* configured per-conn prepared-stmt cache capacity (template only); 0 = disabled */
 	bool conn_broken:1;				/* connection lost or protocol desynchronized — must not return to pool */

--- a/ext/pdo/tests/pdo_pool_009_stmt_refcount_shared_conn.phpt
+++ b/ext/pdo/tests/pdo_pool_009_stmt_refcount_shared_conn.phpt
@@ -6,12 +6,16 @@ pdo_mysql
 true_async
 --SKIPIF--
 <?php
-require_once __DIR__ . '/inc/pdo_pool_test.inc';
+$pdo_pool_inc_dir = getenv('REDIR_TEST_DIR');
+if (false === $pdo_pool_inc_dir) $pdo_pool_inc_dir = __DIR__ . '/';
+require_once $pdo_pool_inc_dir . 'inc/pdo_pool_test.inc';
 PDOPoolTest::skip();
 ?>
 --FILE--
 <?php
-require_once __DIR__ . '/inc/pdo_pool_test.inc';
+$pdo_pool_inc_dir = getenv('REDIR_TEST_DIR');
+if (false === $pdo_pool_inc_dir) $pdo_pool_inc_dir = __DIR__ . '/';
+require_once $pdo_pool_inc_dir . 'inc/pdo_pool_test.inc';
 
 use function Async\spawn;
 use function Async\await;

--- a/ext/pdo/tests/pdo_pool_010_stmt_refcount_destroy_first.phpt
+++ b/ext/pdo/tests/pdo_pool_010_stmt_refcount_destroy_first.phpt
@@ -6,12 +6,16 @@ pdo_mysql
 true_async
 --SKIPIF--
 <?php
-require_once __DIR__ . '/inc/pdo_pool_test.inc';
+$pdo_pool_inc_dir = getenv('REDIR_TEST_DIR');
+if (false === $pdo_pool_inc_dir) $pdo_pool_inc_dir = __DIR__ . '/';
+require_once $pdo_pool_inc_dir . 'inc/pdo_pool_test.inc';
 PDOPoolTest::skip();
 ?>
 --FILE--
 <?php
-require_once __DIR__ . '/inc/pdo_pool_test.inc';
+$pdo_pool_inc_dir = getenv('REDIR_TEST_DIR');
+if (false === $pdo_pool_inc_dir) $pdo_pool_inc_dir = __DIR__ . '/';
+require_once $pdo_pool_inc_dir . 'inc/pdo_pool_test.inc';
 
 use function Async\spawn;
 use function Async\await;

--- a/ext/pdo/tests/pdo_pool_011_stmt_refcount_release_after_all.phpt
+++ b/ext/pdo/tests/pdo_pool_011_stmt_refcount_release_after_all.phpt
@@ -6,12 +6,16 @@ pdo_mysql
 true_async
 --SKIPIF--
 <?php
-require_once __DIR__ . '/inc/pdo_pool_test.inc';
+$pdo_pool_inc_dir = getenv('REDIR_TEST_DIR');
+if (false === $pdo_pool_inc_dir) $pdo_pool_inc_dir = __DIR__ . '/';
+require_once $pdo_pool_inc_dir . 'inc/pdo_pool_test.inc';
 PDOPoolTest::skip();
 ?>
 --FILE--
 <?php
-require_once __DIR__ . '/inc/pdo_pool_test.inc';
+$pdo_pool_inc_dir = getenv('REDIR_TEST_DIR');
+if (false === $pdo_pool_inc_dir) $pdo_pool_inc_dir = __DIR__ . '/';
+require_once $pdo_pool_inc_dir . 'inc/pdo_pool_test.inc';
 
 use function Async\spawn;
 use function Async\await;

--- a/ext/pdo/tests/pdo_pool_012_stmt_refcount_cross_coroutine.phpt
+++ b/ext/pdo/tests/pdo_pool_012_stmt_refcount_cross_coroutine.phpt
@@ -6,12 +6,16 @@ pdo_mysql
 true_async
 --SKIPIF--
 <?php
-require_once __DIR__ . '/inc/pdo_pool_test.inc';
+$pdo_pool_inc_dir = getenv('REDIR_TEST_DIR');
+if (false === $pdo_pool_inc_dir) $pdo_pool_inc_dir = __DIR__ . '/';
+require_once $pdo_pool_inc_dir . 'inc/pdo_pool_test.inc';
 PDOPoolTest::skip();
 ?>
 --FILE--
 <?php
-require_once __DIR__ . '/inc/pdo_pool_test.inc';
+$pdo_pool_inc_dir = getenv('REDIR_TEST_DIR');
+if (false === $pdo_pool_inc_dir) $pdo_pool_inc_dir = __DIR__ . '/';
+require_once $pdo_pool_inc_dir . 'inc/pdo_pool_test.inc';
 
 use function Async\spawn;
 use function Async\await;

--- a/ext/pdo/tests/pdo_pool_013_stmt_refcount_with_txn.phpt
+++ b/ext/pdo/tests/pdo_pool_013_stmt_refcount_with_txn.phpt
@@ -6,12 +6,16 @@ pdo_mysql
 true_async
 --SKIPIF--
 <?php
-require_once __DIR__ . '/inc/pdo_pool_test.inc';
+$pdo_pool_inc_dir = getenv('REDIR_TEST_DIR');
+if (false === $pdo_pool_inc_dir) $pdo_pool_inc_dir = __DIR__ . '/';
+require_once $pdo_pool_inc_dir . 'inc/pdo_pool_test.inc';
 PDOPoolTest::skip();
 ?>
 --FILE--
 <?php
-require_once __DIR__ . '/inc/pdo_pool_test.inc';
+$pdo_pool_inc_dir = getenv('REDIR_TEST_DIR');
+if (false === $pdo_pool_inc_dir) $pdo_pool_inc_dir = __DIR__ . '/';
+require_once $pdo_pool_inc_dir . 'inc/pdo_pool_test.inc';
 
 use function Async\spawn;
 use function Async\await;

--- a/ext/pdo/tests/pdo_pool_014_last_insert_id_with_stmt.phpt
+++ b/ext/pdo/tests/pdo_pool_014_last_insert_id_with_stmt.phpt
@@ -6,12 +6,16 @@ pdo_mysql
 true_async
 --SKIPIF--
 <?php
-require_once __DIR__ . '/inc/pdo_pool_test.inc';
+$pdo_pool_inc_dir = getenv('REDIR_TEST_DIR');
+if (false === $pdo_pool_inc_dir) $pdo_pool_inc_dir = __DIR__ . '/';
+require_once $pdo_pool_inc_dir . 'inc/pdo_pool_test.inc';
 PDOPoolTest::skip();
 ?>
 --FILE--
 <?php
-require_once __DIR__ . '/inc/pdo_pool_test.inc';
+$pdo_pool_inc_dir = getenv('REDIR_TEST_DIR');
+if (false === $pdo_pool_inc_dir) $pdo_pool_inc_dir = __DIR__ . '/';
+require_once $pdo_pool_inc_dir . 'inc/pdo_pool_test.inc';
 
 use function Async\spawn;
 use function Async\await;

--- a/ext/pdo/tests/pdo_pool_015_last_insert_id_no_conn.phpt
+++ b/ext/pdo/tests/pdo_pool_015_last_insert_id_no_conn.phpt
@@ -6,12 +6,16 @@ pdo_mysql
 true_async
 --SKIPIF--
 <?php
-require_once __DIR__ . '/inc/pdo_pool_test.inc';
+$pdo_pool_inc_dir = getenv('REDIR_TEST_DIR');
+if (false === $pdo_pool_inc_dir) $pdo_pool_inc_dir = __DIR__ . '/';
+require_once $pdo_pool_inc_dir . 'inc/pdo_pool_test.inc';
 PDOPoolTest::skip();
 ?>
 --FILE--
 <?php
-require_once __DIR__ . '/inc/pdo_pool_test.inc';
+$pdo_pool_inc_dir = getenv('REDIR_TEST_DIR');
+if (false === $pdo_pool_inc_dir) $pdo_pool_inc_dir = __DIR__ . '/';
+require_once $pdo_pool_inc_dir . 'inc/pdo_pool_test.inc';
 
 use function Async\spawn;
 use function Async\await;

--- a/ext/pdo/tests/pdo_pool_016_error_info_with_conn.phpt
+++ b/ext/pdo/tests/pdo_pool_016_error_info_with_conn.phpt
@@ -6,12 +6,16 @@ pdo_mysql
 true_async
 --SKIPIF--
 <?php
-require_once __DIR__ . '/inc/pdo_pool_test.inc';
+$pdo_pool_inc_dir = getenv('REDIR_TEST_DIR');
+if (false === $pdo_pool_inc_dir) $pdo_pool_inc_dir = __DIR__ . '/';
+require_once $pdo_pool_inc_dir . 'inc/pdo_pool_test.inc';
 PDOPoolTest::skip();
 ?>
 --FILE--
 <?php
-require_once __DIR__ . '/inc/pdo_pool_test.inc';
+$pdo_pool_inc_dir = getenv('REDIR_TEST_DIR');
+if (false === $pdo_pool_inc_dir) $pdo_pool_inc_dir = __DIR__ . '/';
+require_once $pdo_pool_inc_dir . 'inc/pdo_pool_test.inc';
 
 use function Async\spawn;
 use function Async\await;

--- a/ext/pdo/tests/pdo_pool_017_error_info_no_conn.phpt
+++ b/ext/pdo/tests/pdo_pool_017_error_info_no_conn.phpt
@@ -6,12 +6,16 @@ pdo_mysql
 true_async
 --SKIPIF--
 <?php
-require_once __DIR__ . '/inc/pdo_pool_test.inc';
+$pdo_pool_inc_dir = getenv('REDIR_TEST_DIR');
+if (false === $pdo_pool_inc_dir) $pdo_pool_inc_dir = __DIR__ . '/';
+require_once $pdo_pool_inc_dir . 'inc/pdo_pool_test.inc';
 PDOPoolTest::skip();
 ?>
 --FILE--
 <?php
-require_once __DIR__ . '/inc/pdo_pool_test.inc';
+$pdo_pool_inc_dir = getenv('REDIR_TEST_DIR');
+if (false === $pdo_pool_inc_dir) $pdo_pool_inc_dir = __DIR__ . '/';
+require_once $pdo_pool_inc_dir . 'inc/pdo_pool_test.inc';
 
 use function Async\spawn;
 use function Async\await;

--- a/ext/pdo/tests/pdo_pool_019_error_leak_cross_coroutine.phpt
+++ b/ext/pdo/tests/pdo_pool_019_error_leak_cross_coroutine.phpt
@@ -6,12 +6,16 @@ pdo_mysql
 true_async
 --SKIPIF--
 <?php
-require_once __DIR__ . '/inc/pdo_pool_test.inc';
+$pdo_pool_inc_dir = getenv('REDIR_TEST_DIR');
+if (false === $pdo_pool_inc_dir) $pdo_pool_inc_dir = __DIR__ . '/';
+require_once $pdo_pool_inc_dir . 'inc/pdo_pool_test.inc';
 PDOPoolTest::skip();
 ?>
 --FILE--
 <?php
-require_once __DIR__ . '/inc/pdo_pool_test.inc';
+$pdo_pool_inc_dir = getenv('REDIR_TEST_DIR');
+if (false === $pdo_pool_inc_dir) $pdo_pool_inc_dir = __DIR__ . '/';
+require_once $pdo_pool_inc_dir . 'inc/pdo_pool_test.inc';
 
 use function Async\spawn;
 use function Async\await;

--- a/ext/pdo/tests/pdo_pool_020_fresh_conn_error_code_init.phpt
+++ b/ext/pdo/tests/pdo_pool_020_fresh_conn_error_code_init.phpt
@@ -6,12 +6,16 @@ pdo_mysql
 true_async
 --SKIPIF--
 <?php
-require_once __DIR__ . '/inc/pdo_pool_test.inc';
+$pdo_pool_inc_dir = getenv('REDIR_TEST_DIR');
+if (false === $pdo_pool_inc_dir) $pdo_pool_inc_dir = __DIR__ . '/';
+require_once $pdo_pool_inc_dir . 'inc/pdo_pool_test.inc';
 PDOPoolTest::skip();
 ?>
 --FILE--
 <?php
-require_once __DIR__ . '/inc/pdo_pool_test.inc';
+$pdo_pool_inc_dir = getenv('REDIR_TEST_DIR');
+if (false === $pdo_pool_inc_dir) $pdo_pool_inc_dir = __DIR__ . '/';
+require_once $pdo_pool_inc_dir . 'inc/pdo_pool_test.inc';
 
 use function Async\spawn;
 use function Async\await;

--- a/ext/pdo/tests/pdo_pool_021_failed_query_releases_slot.phpt
+++ b/ext/pdo/tests/pdo_pool_021_failed_query_releases_slot.phpt
@@ -1,0 +1,46 @@
+--TEST--
+PDO Pool: a failed query() must not burn a pool slot
+--EXTENSIONS--
+pdo
+pdo_mysql
+true_async
+--SKIPIF--
+<?php
+$pdo_pool_inc_dir = getenv('REDIR_TEST_DIR');
+if (false === $pdo_pool_inc_dir) $pdo_pool_inc_dir = __DIR__ . '/';
+require_once $pdo_pool_inc_dir . 'inc/pdo_pool_test.inc';
+PDOPoolTest::skip();
+?>
+--FILE--
+<?php
+$pdo_pool_inc_dir = getenv('REDIR_TEST_DIR');
+if (false === $pdo_pool_inc_dir) $pdo_pool_inc_dir = __DIR__ . '/';
+require_once $pdo_pool_inc_dir . 'inc/pdo_pool_test.inc';
+
+// PDO::query() detaches the failed statement from its PDO object. That must not
+// be mistaken for "the PDO is gone", or every failed query destroys a pooled
+// connection without ever giving the slot back.
+
+$pdo = PDOPoolTest::poolFactory();
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_SILENT);
+
+$seen = [];
+for ($i = 0; $i < 6; $i++) {
+    $pdo->query("SELECT * FROM definitely_missing_tbl");
+    $seen[] = $pdo->getPool()->activeCount();
+}
+
+// The stash pins at most one connection; the count must not grow with the loop.
+echo "max active: ", max($seen), "\n";
+
+// The pool must still be usable afterwards.
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$row = $pdo->query("SELECT 1 AS n")->fetch(PDO::FETCH_ASSOC);
+echo "still works: ", $row['n'], "\n";
+
+echo "Done\n";
+?>
+--EXPECT--
+max active: 1
+still works: 1
+Done

--- a/ext/pdo_mysql/mysql_statement.c
+++ b/ext/pdo_mysql/mysql_statement.c
@@ -85,7 +85,10 @@ static int pdo_mysql_stmt_dtor(pdo_stmt_t *stmt) /* {{{ */
 
 	pdo_mysql_free_result(S);
 	if (S->einfo.errmsg) {
-		pefree(S->einfo.errmsg, stmt->dbh->is_persistent);
+		/* stmt->dbh may already be freed (GC can destroy the PDO first), and a
+		 * pooled slot is never persistent — so fall back to non-persistent. */
+		pefree(S->einfo.errmsg,
+			php_pdo_stmt_valid_db_obj_handle(stmt) && stmt->dbh->is_persistent);
 		S->einfo.errmsg = NULL;
 	}
 	if (S->stmt) {

--- a/ext/pdo_sqlite/tests/pool_006_stmt_outlives_pdo_after_scheduler_launch.phpt
+++ b/ext/pdo_sqlite/tests/pool_006_stmt_outlives_pdo_after_scheduler_launch.phpt
@@ -1,0 +1,56 @@
+--TEST--
+PDO_SQLite Pool: statement outliving the PDO after a lazy scheduler launch (php-async #200)
+--EXTENSIONS--
+pdo
+pdo_sqlite
+true_async
+--FILE--
+<?php
+
+// The main flow is promoted into the main coroutine on the fly, the first time
+// something needs the scheduler (here: an async stream write). A connection
+// acquired before that promotion must stay bound to the same context, or it is
+// treated as orphaned afterwards and released to the pool twice.
+
+function work(string $dbfile, string $dir): void
+{
+    $pdo = new PDO("sqlite:" . $dbfile, null, null, [
+        PDO::ATTR_ERRMODE      => PDO::ERRMODE_EXCEPTION,
+        PDO::ATTR_POOL_ENABLED => true,
+        PDO::ATTR_POOL_MIN     => 1,
+        PDO::ATTR_POOL_MAX     => 8,
+    ]);
+    $pdo->exec("CREATE TABLE t (id TEXT PRIMARY KEY, v TEXT)");
+
+    // Kept in a local so the statement, not the PDO, holds the last dbh ref.
+    $stmt = $pdo->prepare("INSERT INTO t (id, v) VALUES (:id, :v)");
+    $stmt->execute(['id' => 'a', 'v' => 'b']);
+
+    // Launches the scheduler: the binding key must not change under us.
+    file_put_contents($dir . '/x.txt', "hi\n");
+
+    // Both locals are destroyed here; the statement is freed last.
+}
+
+$dir = sys_get_temp_dir() . '/pdo_pool_200_' . getmypid();
+@mkdir($dir, 0775, true);
+$dbfile = $dir . '/x.db';
+
+work($dbfile, $dir);
+echo "survived\n";
+
+// Same shape again, now with the scheduler already running.
+work($dbfile . '2', $dir);
+echo file_get_contents($dir . '/x.txt');
+
+@unlink($dbfile);
+@unlink($dbfile . '2');
+@unlink($dir . '/x.txt');
+@rmdir($dir);
+
+echo "Done\n";
+?>
+--EXPECT--
+survived
+hi
+Done

--- a/ext/pdo_sqlite/tests/pool_007_stmt_outlives_its_coroutine.phpt
+++ b/ext/pdo_sqlite/tests/pool_007_stmt_outlives_its_coroutine.phpt
@@ -1,0 +1,52 @@
+--TEST--
+PDO_SQLite Pool: statement outliving the coroutine that acquired its connection (php-async #200)
+--EXTENSIONS--
+pdo
+pdo_sqlite
+true_async
+--FILE--
+<?php
+
+use function Async\spawn;
+use function Async\await;
+
+// The coroutine binding is freed as soon as the coroutine finalizes. A statement
+// still holding the connection must take ownership of it there, or the pooled
+// connection keeps a back-pointer into the freed binding.
+
+$dbfile = tempnam(sys_get_temp_dir(), 'pdo_sqlite_pool_');
+
+$pdo = new PDO("sqlite:" . $dbfile, null, null, [
+    PDO::ATTR_ERRMODE      => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_POOL_ENABLED => true,
+    PDO::ATTR_POOL_MIN     => 1,
+    PDO::ATTR_POOL_MAX     => 4,
+]);
+$pdo->exec("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)");
+
+$escaped = null;
+
+await(spawn(function () use ($pdo, &$escaped) {
+    $escaped = $pdo->prepare("INSERT INTO t (v) VALUES (?)");
+    $escaped->execute(['x']);
+}));
+
+echo "coroutine finished\n";
+
+unset($escaped);   // statement destroyed after its coroutine is already gone
+echo "statement freed\n";
+
+// The connection must be usable again, not leaked or double-released.
+$row = $pdo->query("SELECT COUNT(*) AS n FROM t")->fetch(PDO::FETCH_ASSOC);
+echo "rows: ", $row['n'], "\n";
+
+unset($pdo);
+@unlink($dbfile);
+
+echo "Done\n";
+?>
+--EXPECT--
+coroutine finished
+statement freed
+rows: 1
+Done

--- a/ext/pdo_sqlite/tests/pool_008_orphaned_conn_txn_rollback.phpt
+++ b/ext/pdo_sqlite/tests/pool_008_orphaned_conn_txn_rollback.phpt
@@ -1,0 +1,59 @@
+--TEST--
+PDO_SQLite Pool: open transaction on an orphaned connection is rolled back (php-async #200)
+--EXTENSIONS--
+pdo
+pdo_sqlite
+true_async
+--FILE--
+<?php
+
+use function Async\spawn;
+use function Async\await;
+
+// A statement outlives the coroutine that began a transaction. Once the binding
+// is gone nobody can commit it, so releasing the connection must roll it back
+// rather than pin it out of the pool forever.
+
+$dbfile = tempnam(sys_get_temp_dir(), 'pdo_sqlite_pool_');
+
+$pdo = new PDO("sqlite:" . $dbfile, null, null, [
+    PDO::ATTR_ERRMODE      => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_POOL_ENABLED => true,
+    PDO::ATTR_POOL_MIN     => 1,
+    PDO::ATTR_POOL_MAX     => 2,
+]);
+$pdo->exec("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)");
+
+$escaped = null;
+
+await(spawn(function () use ($pdo, &$escaped) {
+    $pdo->beginTransaction();
+    $escaped = $pdo->prepare("INSERT INTO t (v) VALUES (?)");
+    $escaped->execute(['uncommitted']);
+    // No commit, no rollback: the coroutine just ends.
+}));
+
+echo "coroutine finished\n";
+
+unset($escaped);
+echo "statement freed\n";
+
+// Rolled back, so the row must be gone, and the pool must still hand out conns.
+$row = $pdo->query("SELECT COUNT(*) AS n FROM t")->fetch(PDO::FETCH_ASSOC);
+echo "rows: ", $row['n'], "\n";
+
+$pdo->exec("INSERT INTO t (v) VALUES ('after')");
+$row = $pdo->query("SELECT COUNT(*) AS n FROM t")->fetch(PDO::FETCH_ASSOC);
+echo "rows after reuse: ", $row['n'], "\n";
+
+unset($pdo);
+@unlink($dbfile);
+
+echo "Done\n";
+?>
+--EXPECT--
+coroutine finished
+statement freed
+rows: 0
+rows after reuse: 1
+Done

--- a/ext/pdo_sqlite/tests/pool_009_gc_frees_pdo_before_stmt.phpt
+++ b/ext/pdo_sqlite/tests/pool_009_gc_frees_pdo_before_stmt.phpt
@@ -1,0 +1,54 @@
+--TEST--
+PDO_SQLite Pool: GC freeing the PDO before its statement (php-async #200)
+--EXTENSIONS--
+pdo
+pdo_sqlite
+true_async
+--FILE--
+<?php
+
+// Two cycles collected in one GC run. The PDO's cycle is buffered first, so the
+// dbh is freed before the statement that still borrows a pooled connection —
+// stmt->dbh must not be dereferenced on that path.
+
+#[AllowDynamicProperties]
+class MyPDO extends PDO { public $keep; }
+
+#[AllowDynamicProperties]
+class MyStmt extends PDOStatement { public $b; private function __construct() {} }
+
+$dbfile = tempnam(sys_get_temp_dir(), 'pdo_sqlite_pool_');
+
+$pdo = new MyPDO("sqlite:" . $dbfile, null, null, [
+    PDO::ATTR_ERRMODE         => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_POOL_ENABLED    => true,
+    PDO::ATTR_POOL_MIN        => 1,
+    PDO::ATTR_POOL_MAX        => 4,
+    PDO::ATTR_STATEMENT_CLASS => [MyStmt::class],
+]);
+$pdo->exec("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)");
+
+$a = new stdClass;
+$a->pdo = $pdo;
+$pdo->keep = $a;                 // cycle 1: PDO
+
+$stmt = $pdo->prepare("INSERT INTO t (v) VALUES (?)");
+$stmt->execute(['x']);
+
+$b = new stdClass;
+$b->stmt = $stmt;
+$stmt->b = $b;                   // cycle 2: statement
+
+unset($a, $pdo, $b, $stmt);
+
+var_dump(gc_collect_cycles() > 0);
+echo "survived\n";
+
+@unlink($dbfile);
+
+echo "Done\n";
+?>
+--EXPECT--
+bool(true)
+survived
+Done

--- a/ext/pdo_sqlite/tests/pool_010_txn_survives_scheduler_launch.phpt
+++ b/ext/pdo_sqlite/tests/pool_010_txn_survives_scheduler_launch.phpt
@@ -1,0 +1,45 @@
+--TEST--
+PDO_SQLite Pool: transaction opened before the scheduler launch survives it (php-async #200)
+--EXTENSIONS--
+pdo
+pdo_sqlite
+true_async
+--FILE--
+<?php
+
+// The scheduler promotes the running main flow into the main coroutine on the
+// first async operation. If the pool keyed its binding by coroutine identity,
+// the key would change mid-transaction and commit() would no longer find it.
+
+$dbfile = tempnam(sys_get_temp_dir(), 'pdo_sqlite_pool_');
+$marker = tempnam(sys_get_temp_dir(), 'pdo_sqlite_pool_launch_');
+
+$pdo = new PDO("sqlite:" . $dbfile, null, null, [
+    PDO::ATTR_ERRMODE      => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_POOL_ENABLED => true,
+    PDO::ATTR_POOL_MIN     => 0,
+    PDO::ATTR_POOL_MAX     => 4,
+]);
+$pdo->exec("CREATE TABLE t (v TEXT)");
+
+$pdo->beginTransaction();
+$pdo->exec("INSERT INTO t VALUES ('x')");
+
+// Launches the scheduler in the middle of the open transaction.
+file_put_contents($marker, "launch\n");
+
+$pdo->commit();
+echo "commit ok\n";
+
+echo "rows: ", $pdo->query("SELECT COUNT(*) FROM t")->fetchColumn(), "\n";
+
+unset($pdo);
+@unlink($dbfile);
+@unlink($marker);
+
+echo "Done\n";
+?>
+--EXPECT--
+commit ok
+rows: 1
+Done

--- a/ext/pdo_sqlite/tests/pool_011_pre_launch_binding_releases_at_end.phpt
+++ b/ext/pdo_sqlite/tests/pool_011_pre_launch_binding_releases_at_end.phpt
@@ -1,0 +1,51 @@
+--TEST--
+PDO_SQLite Pool: binding created before the scheduler still releases at main-coroutine end (php-async #200)
+--EXTENSIONS--
+pdo
+pdo_sqlite
+true_async
+--FILE--
+<?php
+
+use function Async\spawn;
+
+// A binding created before the scheduler exists gets no coroutine callback at
+// creation time. Once the main coroutine appears it must be attached on reuse,
+// otherwise nothing releases the slot when the main flow ends and a coroutine
+// waiting for the only connection waits forever.
+
+$dbfile = tempnam(sys_get_temp_dir(), 'pdo_sqlite_pool_');
+$marker = tempnam(sys_get_temp_dir(), 'pdo_sqlite_pool_launch_');
+
+$pdo = new PDO("sqlite:" . $dbfile, null, null, [
+    PDO::ATTR_ERRMODE      => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_POOL_ENABLED => true,
+    PDO::ATTR_POOL_MIN     => 0,
+    PDO::ATTR_POOL_MAX     => 1,
+]);
+
+// Pre-scheduler: creates the key-0 binding with no coroutine callback.
+$pdo->exec("CREATE TABLE t (v TEXT)");
+
+file_put_contents($marker, "launch\n");
+
+// Re-acquire after the launch: this is where the callback must be attached.
+$pdo->beginTransaction();
+$pdo->exec("INSERT INTO t VALUES ('uncommitted')");
+
+spawn(function () use ($pdo, $dbfile, $marker) {
+    // Needs the only slot, so it can only run once the main flow lets go.
+    echo "coroutine got conn, rows: ", $pdo->query("SELECT COUNT(*) FROM t")->fetchColumn(), "\n";
+    @unlink($dbfile);
+    @unlink($marker);
+    echo "Done\n";
+});
+
+// Main flow ends with the transaction still open; the main coroutine's
+// finalize must roll it back and return the connection.
+echo "main code ends\n";
+?>
+--EXPECT--
+main code ends
+coroutine got conn, rows: 0
+Done


### PR DESCRIPTION
Fixes true-async/php-async#200.

## The bug

`async_scheduler_launch()` promotes the already-running main flow into the main coroutine on the fly, the first time something needs the scheduler (in the report: `file_put_contents`). The PDO pool keys its per-context binding by coroutine identity, so `ZEND_ASYNC_CURRENT_COROUTINE` going `NULL -> main` mid-execution changed the key underneath a live connection.

Traced with an instrumented build:

```
acquire coro=(nil) key=0            <- exec()/prepare(), before the launch
peek    coro=0x...2f00 key=3        <- statement destructor, after it
        binding=(nil)               <- lookup misses
free_conn conn=0x...3400 methods=0x562dc21eed60
free_conn conn=0x...3400 methods=0x71bdd1ca3600   <- same conn, freed twice
```

The statement destructor missed the binding, took the "orphaned connection" branch and returned the conn to the pool; the binding still owned it and returned it again at pool destroy. The idle list then held it twice and the pool destructor freed it twice — the `conn->methods` guard in `pdo_pool_free_conn` passed because the memory was non-NULL, not because it was valid.

## The fix

**Key stability.** The main flow maps to binding key 0 whether or not the scheduler has launched, so one execution context keeps one binding across the promotion. Object handle 0 is reserved by the objects store, so no coroutine collides with it.

**Ownership.** A pooled slot carries an `owner_binding` back-pointer. Every release path detaches the owner first, so a double release is impossible even when the key legitimately drifts — a statement destroyed in a different coroutine, or a binding freed at coroutine finalize while statements still borrow the connection.

**Destruction order.** A statement no longer dereferences `stmt->dbh` on the release path at all. The slot holds its own reference on the pool event and is released through `conn->pool`, so it works in any order, including GC freeing the PDO before the statement. `pdo_mysql_stmt_dtor` had the same stale-`dbh` read (`pefree(..., stmt->dbh->is_persistent)`) and is now guarded exactly like the stmt-cache code eight lines below it.

`PDO_DRIVER_API` is bumped for the new `pdo_dbh_t` field.

## Tests

Seven new tests, all sqlite-based except one so they need no server:

| test | covers |
|---|---|
| `pool_006` | the reported scenario: statement outlives the PDO after a lazy scheduler launch |
| `pool_007` | statement outlives the coroutine that acquired its connection |
| `pool_008` | open transaction on an orphaned connection is rolled back |
| `pool_009` | GC frees the PDO before its statement |
| `pool_010` | transaction opened before the scheduler launch survives it |
| `pool_011` | pre-launch binding still releases at main-coroutine end |
| `pdo_pool_021` | a failed `query()` does not burn a pool slot |

Each was verified to fail with its corresponding change reverted, not merely to pass — `pool_010` and `pool_011` in particular, because the ownership layer masks the key-stability fix: without them, reverting the core change of this PR passed all 22 existing tests silently while losing a committed transaction and deadlocking a coroutine.

The pool tests in `ext/pdo/tests` also resolve their helper through `REDIR_TEST_DIR` instead of `__DIR__`. Under `--REDIRECTTEST--` run-tests materialises the skip file in the driver's directory, so `__DIR__` pointed at `ext/pdo_sqlite/tests/` and 11 tests borked out without running at all. BORKED went 22 -> 0.

## Verification

| | |
|---|---|
| `ext/pdo_sqlite` + `ext/pdo_mysql` + `ext/pdo` | 706 tests, 0 failed, 0 borked |
| full async suite | 1124 passed, 0 failed |
| pool tests | sqlite 11/11, mysql 13/13 |
| valgrind on all four reproducers | 0 errors, no definite leaks |

Reproducers checked under `USE_ZEND_ALLOC=0 valgrind`: the original report, statement-outlives-coroutine, the GC-ordering case, and the failed-`query()` slot accounting. The GC case is worth calling out — it printed `Done` and exited 0 while writing into freed memory, so it was only visible under valgrind.

## Not in this PR

Found while auditing this code path, filed separately: true-async/php-async#201, #202, #203. #202 in particular is now precisely located (`pdo_pool.c` coroutine-finalize callback dereferences `binding->dbh` after a release that suspended) but its fix belongs after this lands, since it touches the same paths.