### PR TITLE
Add ZEND_OBJECT_TRANSFER_RELEASE so a transit shell can free what it owns

### DIFF
--- a/Zend/zend_object_handlers.h
+++ b/Zend/zend_object_handlers.h
@@ -185,6 +185,12 @@ typedef zend_object* (*zend_object_clone_obj_with_t)(zend_object *object, const 
 typedef enum {
 	ZEND_OBJECT_TRANSFER,  /* emalloc → pemalloc (send to another thread) */
 	ZEND_OBJECT_LOAD,      /* pemalloc → emalloc (receive in target thread) */
+	/* The transit shell is being freed: release what TRANSFER acquired into it.
+	 * The handler frees its own C state and returns NULL; it must not call
+	 * default_fn, and `ctx` may be NULL because a release runs outside a
+	 * request. Without this kind, anything a handler stores in the shell is
+	 * unreachable — free_obj never runs for a shell. */
+	ZEND_OBJECT_TRANSFER_RELEASE,
 } zend_object_transfer_kind_t;
 
 typedef zend_object* (*zend_object_transfer_default_fn)(

--- a/Zend/zend_weakrefs.c
+++ b/Zend/zend_weakrefs.c
@@ -818,6 +818,12 @@ static zend_object *zend_weakref_transfer_obj(
 {
 	(void) default_fn;
 
+	if (kind == ZEND_OBJECT_TRANSFER_RELEASE) {
+		/* The transit wrapper owns nothing of its own: the referent slot and the
+		 * class name are freed by the generic release walk. */
+		return NULL;
+	}
+
 	if (kind == ZEND_OBJECT_TRANSFER) {
 		zend_weakref *wr = zend_weakref_from(object);
 		zend_object *referent = wr->referent;
@@ -874,6 +880,12 @@ static zend_object *zend_weakmap_transfer_obj(
 	zend_object_transfer_kind_t kind, zend_object_transfer_default_fn default_fn)
 {
 	(void) default_fn;
+
+	if (kind == ZEND_OBJECT_TRANSFER_RELEASE) {
+		/* The transit wrapper owns nothing of its own: the key/value slots and
+		 * the class name are freed by the generic release walk. */
+		return NULL;
+	}
 
 	if (kind == ZEND_OBJECT_TRANSFER) {
 		zend_weakmap *wm = zend_weakmap_from(object);


### PR DESCRIPTION
`transfer_obj` has TRANSFER and LOAD and nothing else. A handler that puts C state into the transit shell — a refcounted pointer, a persistent string — cannot get it back: `free_obj` never runs for a shell, so whatever the handler stored there is unreachable once the shell is released.

Handlers work around this by hand where they can. php-async frees a closure snapshot from its release walk by recognising the shell through a non-NULL `properties`. The TrueAsync server frees its worker shells from the object that owns them (`http_server_release_worker_shell`, added after issue #93 found ~10KB leaking per reload rotation). Where no owner exists, the state leaks: a `TrueAsync\Room` transferred into a `ThreadPool` task leaked its topic-hub reference — 21,608 bytes of hub plus a persistent topic string — with nobody to free them.

The third kind gives the class a say. Contract: the handler frees its own C state and returns NULL, must not call `default_fn`, and must tolerate a NULL `ctx`, because a release runs outside a request. php-async dispatches it from `thread_release_transferred_object` (separate PR).

`WeakReference` and `WeakMap` are the only `transfer_obj` handlers in Zend, and both branch on TRANSFER while treating everything else as LOAD — reaching that branch with a NULL `ctx` and a NULL `default_fn` crashes. They now refuse the new kind explicitly. Their transit wrappers own nothing of their own: the referent slots and the class-name copy are freed by the generic release walk.

## Measurements

Built and installed locally, then ran the whole async suite: `ext/async` 3 failed, all three pre-existing (`__DIR__` resolves the ext/async symlink, so their `include` of a php-src helper four levels up misses). Before the WeakReference and WeakMap guards, six thread-transfer tests died with `Termsig` — which is what the guards are for, and what a handler hitting its LOAD branch on the new kind looks like.