### PR TITLE
Free each thread's strtod Bigint pool

### DIFF
--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -876,6 +876,11 @@ static void executor_globals_dtor(zend_executor_globals *executor_globals) /* {{
 		zend_hash_destroy(executor_globals->zend_constants);
 		free(executor_globals->zend_constants);
 	}
+
+	/* Every thread pools its own Bigints, and zend_shutdown_strtod() reaches only
+	 * the main thread's: without this a thread that ever formatted or parsed a
+	 * double leaves them behind when its storage goes. */
+	zend_strtod_state_dtor(&executor_globals->strtod_state);
 }
 /* }}} */
 

--- a/Zend/zend_strtod.c
+++ b/Zend/zend_strtod.c
@@ -545,8 +545,8 @@ Bigint {
  static Bigint *freelist[Kmax+1];
 #endif
 
-static void destroy_freelist(void);
-static void free_p5s(void);
+static void destroy_freelist(zend_strtod_state *state);
+static void free_p5s(zend_strtod_state *state);
 
 #ifdef MULTIPLE_THREADS
 static MUTEX_T dtoa_mutex;
@@ -555,10 +555,20 @@ static MUTEX_T pow5mult_mutex;
 
 ZEND_API int zend_shutdown_strtod(void) /* {{{ */
 {
-	destroy_freelist();
-	free_p5s();
+	zend_strtod_state_dtor(&EG(strtod_state));
 
 	return 1;
+}
+/* }}} */
+
+/* Frees the Bigints one thread pooled. Bfree recycles rather than releasing, so
+ * every thread that formats or parses a double keeps a handful for its life. The
+ * state travels as an argument because TSRM runs a thread's storage dtor from
+ * whichever thread performs the shutdown, and EG() there is somebody else's. */
+ZEND_API void zend_strtod_state_dtor(zend_strtod_state *state) /* {{{ */
+{
+	destroy_freelist(state);
+	free_p5s(state);
 }
 /* }}} */
 
@@ -4605,33 +4615,38 @@ ZEND_API char *zend_gcvt(double value, int ndigit, char dec_point, char exponent
 	return (buf);
 }
 
-static void destroy_freelist(void)
+/* The two pools are reached through a thread's own state from here on, so the
+ * EG() shorthands above must not swallow the field names. */
+#undef freelist
+#undef p5s
+
+static void destroy_freelist(zend_strtod_state *state)
 {
 	int i;
 	Bigint *tmp;
 
 	ACQUIRE_DTOA_LOCK(0)
 	for (i = 0; i <= Kmax; i++) {
-		Bigint **listp = &freelist[i];
+		Bigint **listp = &state->freelist[i];
 		while ((tmp = *listp) != NULL) {
 			*listp = tmp->next;
 			FREE(tmp);
 		}
-		freelist[i] = NULL;
+		state->freelist[i] = NULL;
 	}
 	FREE_DTOA_LOCK(0)
 }
 
-static void free_p5s(void)
+static void free_p5s(zend_strtod_state *state)
 {
 	Bigint **listp, *tmp;
 
 	ACQUIRE_DTOA_LOCK(1)
-	listp = &p5s;
+	listp = &state->p5s;
 	while ((tmp = *listp) != NULL) {
 		*listp = tmp->next;
 		FREE(tmp);
 	}
-	p5s = NULL;
+	state->p5s = NULL;
 	FREE_DTOA_LOCK(1)
 }

--- a/Zend/zend_strtod.h
+++ b/Zend/zend_strtod.h
@@ -37,6 +37,9 @@ ZEND_API double zend_hex_strtod(const char *str, const char **endptr);
 ZEND_API double zend_oct_strtod(const char *str, const char **endptr);
 ZEND_API double zend_bin_strtod(const char *str, const char **endptr);
 ZEND_API int zend_shutdown_strtod(void);
+/* Releases what one thread pooled. Called for every thread's state, not only the
+ * one zend_shutdown_strtod() reaches. */
+ZEND_API void zend_strtod_state_dtor(zend_strtod_state *state);
 END_EXTERN_C()
 
 /* double limits */


### PR DESCRIPTION
## What was broken

`Bfree()` does not release a `Bigint`; it pushes it onto `freelist[k]`, which under ZTS is `EG(strtod_state).freelist` — one pool per thread. The only thing that empties a pool is `destroy_freelist()`, reachable solely through `zend_shutdown_strtod()`, which runs once, on the main thread. `executor_globals_ctor` zeroes the state for every new thread and `executor_globals_dtor` never touched it.

So every thread that formatted or parsed a double leaked its pooled Bigints when its TSRM storage went. Measured with a `ThreadPool` worker doing one `sprintf('%6.3f', 1.5)`:

```
68 bytes in 2 blocks are definitely lost
```

— a 36-byte `Balloc(1)` from `d2b()` and a 32-byte `Balloc(0)` from `rv_alloc()`. Four workers, one float each: 272 bytes in 8 blocks, exactly linear. It is small per thread and unbounded per process: a pool that rotates its workers pays it again on every rotation.

## The change

`destroy_freelist()` and `free_p5s()` take the state to free instead of reaching through `EG()`, and `executor_globals_dtor()` frees the departing thread's pool. The state has to travel as an argument: TSRM runs a thread's storage destructor from whichever thread performs the shutdown, so `EG()` there belongs to somebody else.

`zend_shutdown_strtod()` keeps its signature and now goes through the same path for the main thread. Running it before the destructor is safe — the teardown NULLs both lists, so the second pass finds nothing.

The two `#undef`s before the teardown are needed because `freelist` and `p5s` are macros over `EG(strtod_state)` for the rest of the file, and they would otherwise swallow the field names in `state->freelist`.

## Measurements

| | before | after |
|---|---|---|
| one pool worker formatting one double | 68 bytes definitely lost in 2 blocks | 0 |
| four workers, one double each | 272 in 8 | 0 |

`Zend/tests`: 5398 passed, 129 skipped, 0 failed. `ext/standard/tests/math`: 164 passed, 0 failed. Build is ZTS, debug.

Found while chasing a leak in another project against this fork; the same code is in php-src master, so this is not fork-specific.