### PR TITLE
PDO: keep a cancellation on top of the driver error it caused

### DIFF
--- a/ext/pdo/pdo_dbh.c
+++ b/ext/pdo/pdo_dbh.c
@@ -33,8 +33,29 @@
 #include "zend_observer.h"
 #include "zend_extensions.h"
 #include "pdo_pool.h"
+#include "Zend/zend_async_API.h"
 
 static bool pdo_dbh_attribute_set(pdo_dbh_t *dbh, zend_long attr, zval *value, uint32_t value_arg_num);
+
+/* A driver error raised while the coroutine is being cancelled describes the
+ * cancellation, not a database fault: the socket was torn down under it. The
+ * cancellation stays on top and the driver error is attached to it, so
+ * catch (AsyncCancellation) keeps working and the detail is not lost. */
+static bool pdo_keep_pending_cancellation(zend_object *driver_exception)
+{
+	if (EXPECTED(EG(exception) == NULL)) {
+		return false;
+	}
+
+	const zend_class_entry *cancellation_ce = ZEND_ASYNC_GET_EXCEPTION_CE(ZEND_ASYNC_EXCEPTION_CANCELLATION);
+
+	if (cancellation_ce == NULL || !instanceof_function(EG(exception)->ce, cancellation_ce)) {
+		return false;
+	}
+
+	zend_exception_set_previous(EG(exception), driver_exception);
+	return true;
+}
 
 void pdo_throw_exception(unsigned int driver_errcode, char *driver_errmsg, pdo_error_type *pdo_error)
 {
@@ -59,6 +80,11 @@ void pdo_throw_exception(unsigned int driver_errcode, char *driver_errmsg, pdo_e
 		);
 		zend_string_release_ex(pdo_exception_message, false);
 		zval_ptr_dtor(&error_info);
+
+		if (pdo_keep_pending_cancellation(Z_OBJ(pdo_exception))) {
+			return;
+		}
+
 		zend_throw_exception_object(&pdo_exception);
 }
 


### PR DESCRIPTION
## The defect

Cancelling a coroutine while the driver is still connecting tears the socket down under it. mysqlnd then reports a connection failure of its own, `pdo_throw_exception` throws it as `PDOException`, and the engine attaches the pending `AsyncCancellation` to it as `previous`. The exception the caller sees is therefore the driver error, `catch (Async\AsyncCancellation)` no longer matches, and the coroutine dies with an uncaught `PDOException`.

Reproduced locally by cancelling 1000 µs after `spawn()`:

```
before:  PDOException: SQLSTATE[HY000] [2002] Operation canceled
           previous: Async\AsyncCancellation: Coroutine cancelled
after:   cancelled
```

This is what makes `tests/pdo_mysql/009-pdo_cancellation.phpt` flake in CI, where connecting is slow enough for the cancellation to land inside `PDO::__construct`: https://github.com/true-async/php-async/actions/runs/32065048014/job/95495005584

## The fix

When PDO is about to throw and a cancellation is already pending, the cancellation stays on top and the driver error becomes its `previous`. Nothing is lost — the connection error is still there for anyone who walks the chain — but the type the caller catches is the one that describes what happened.

`zend_exception_set_previous` takes ownership of the object passed to it, so the reference from `object_init_ex` is handed over, not leaked.

## Tests

The regression test lives in the extension repository, where the async PDO harness is: `true-async/php-async` → `tests/pdo_mysql/029-cancel_during_connect.phpt`. It cancels at a spread of delays so that some attempts land inside the connect, and requires the outcomes to be exactly `cancelled`, `cancelled before start` and `connected`. Without this change it fails three runs out of three with `leaked PDOException`.

Suites with the fix: `ext/pdo` + `ext/pdo_sqlite` 284/284, `ext/async/tests/pdo_mysql` 28/28 against a live server, `ext/async/tests/pdo_sqlite` 21/21, `ext/async/tests/pool` 67/67.