### PR TITLE
#234: adjust the GC threshold from the coroutine that collects

### DIFF
--- a/Zend/zend_gc.c
+++ b/Zend/zend_gc.c
@@ -719,7 +719,10 @@ static void gc_adjust_threshold(int count)
  * zend_gc_coroutine() from the count that run reports. */
 static void gc_adjust_threshold_or_defer(int count)
 {
-	if (gc_collect_is_deferred()) {
+	/* A coroutine owes the run, so `count` is that hand-off's 0 rather than a measurement.
+	 * No coroutine means the collection either ran inline or could not be spawned at all, and
+	 * in both cases the count in hand is the honest one. */
+	if (gc_collect_is_deferred() && GC_G(gc_coroutine) != NULL) {
 		GC_G(adjust_threshold) = true;
 		return;
 	}
@@ -2247,7 +2250,6 @@ static zend_always_inline void start_gc_in_coroutine(void)
 	}
 
 	if (UNEXPECTED(new_gc_coroutine() == NULL)) {
-		GC_G(adjust_threshold) = false;
 		return;
 	}
 }

--- a/Zend/zend_gc.c
+++ b/Zend/zend_gc.c
@@ -295,6 +295,7 @@ typedef struct _zend_gc_globals {
 	uint32_t dtor_end;
 	zend_fiber *dtor_fiber;
 	bool dtor_fiber_running;
+	bool adjust_threshold; /* the collection deferred to the GC coroutine came from a full root buffer */
 	zend_async_scope_t *gc_scope; /* async scope where GC was started */
 	zend_async_scope_t *dtor_scope; /* async scope running destructors */
 	zend_coroutine_t *gc_coroutine; /* coroutine where GC was started */
@@ -546,6 +547,7 @@ static void gc_globals_ctor_ex(zend_gc_globals *gc_globals)
 	gc_globals->gc_scope = NULL;
 	gc_globals->dtor_scope = NULL;
 	gc_globals->gc_coroutine = NULL;
+	gc_globals->adjust_threshold = false;
 	gc_globals->microtask = NULL;
 
 #if GC_BENCH
@@ -598,6 +600,7 @@ void gc_reset(void)
 		GC_G(dtor_end) = 0;
 		GC_G(dtor_fiber) = NULL;
 		GC_G(dtor_fiber_running) = false;
+		GC_G(adjust_threshold) = false;
 
 #if GC_BENCH
 		GC_G(root_buf_length) = 0;
@@ -702,6 +705,12 @@ static void gc_adjust_threshold(int count)
 	}
 }
 
+/* A collection requested now goes to the GC coroutine instead of running inline. */
+static zend_always_inline bool gc_collect_is_deferred(void)
+{
+	return ZEND_ASYNC_IS_ACTIVE && ZEND_ASYNC_CURRENT_COROUTINE != GC_G(gc_coroutine);
+}
+
 /* Perform a GC run and then add a node as a possible root. */
 static zend_never_inline void ZEND_FASTCALL gc_possible_root_when_full(zend_refcounted *ref)
 {
@@ -712,13 +721,32 @@ static zend_never_inline void ZEND_FASTCALL gc_possible_root_when_full(zend_refc
 	ZEND_ASSERT(GC_INFO(ref) == 0);
 
 	if (GC_G(gc_enabled) && !GC_G(gc_active)) {
-		GC_ADDREF(ref);
-		gc_adjust_threshold(gc_collect_cycles());
-		if (UNEXPECTED(GC_DELREF(ref) == 0)) {
-			rc_dtor_func(ref);
-			return;
-		} else if (UNEXPECTED(GC_INFO(ref))) {
-			return;
+		const bool deferred = gc_collect_is_deferred();
+
+		if (deferred) {
+			/* The run goes to the GC coroutine and this caller is told 0 nodes were collected.
+			 * Adjusting on that 0 raises the threshold by a full step after every full root
+			 * buffer, so the coroutine adjusts instead, from the count it really collected. */
+			GC_G(adjust_threshold) = true;
+		}
+
+		/* A GC coroutine already spawned covers this buffer too, and a second request would
+		 * return at once - a call made for every root buffered until that coroutine runs. */
+		if (!deferred || GC_G(gc_coroutine) == NULL) {
+			GC_ADDREF(ref);
+
+			if (deferred) {
+				gc_collect_cycles();
+			} else {
+				gc_adjust_threshold(gc_collect_cycles());
+			}
+
+			if (UNEXPECTED(GC_DELREF(ref) == 0)) {
+				rc_dtor_func(ref);
+				return;
+			} else if (UNEXPECTED(GC_INFO(ref))) {
+				return;
+			}
 		}
 	}
 
@@ -2168,7 +2196,16 @@ static zend_never_inline bool gc_call_destructors_in_coroutine(void)
 static void zend_gc_coroutine(void)
 {
 	GC_TRACE("GC coroutine started");
-	zend_gc_collect_cycles();
+
+	const int count = zend_gc_collect_cycles();
+
+	/* One run answers every root buffer that filled while it was pending, so one adjustment
+	 * covers them all. */
+	if (GC_G(adjust_threshold)) {
+		GC_G(adjust_threshold) = false;
+		gc_adjust_threshold(count);
+	}
+
 	GC_G(gc_coroutine) = NULL;
 	GC_TRACE("GC coroutine finished");
 }
@@ -2176,6 +2213,16 @@ static void zend_gc_coroutine(void)
 static zend_string* zend_gc_coroutine_info(zend_async_event_t *event)
 {
 	return zend_coroutine_gen_info((zend_coroutine_t *) event, "zend_gc_coroutine");
+}
+
+/* A GC coroutine cancelled before it starts never reaches zend_gc_coroutine(), so the state
+ * it would have cleared is cleared here instead. */
+static void gc_coroutine_dispose(zend_coroutine_t *coroutine)
+{
+	if (coroutine == GC_G(gc_coroutine)) {
+		GC_G(gc_coroutine) = NULL;
+		GC_G(adjust_threshold) = false;
+	}
 }
 
 static zend_always_inline zend_coroutine_t* new_gc_coroutine(void)
@@ -2190,6 +2237,7 @@ static zend_always_inline zend_coroutine_t* new_gc_coroutine(void)
 
 	coroutine->internal_entry = zend_gc_coroutine;
 	coroutine->event.info = zend_gc_coroutine_info;
+	coroutine->extended_dispose = gc_coroutine_dispose;
 
 	return coroutine;
 }
@@ -2217,7 +2265,7 @@ static zend_always_inline void start_gc_in_coroutine(void)
 /* Perform a garbage collection run. The default implementation of gc_collect_cycles. */
 ZEND_API int zend_gc_collect_cycles(void)
 {
-	if (UNEXPECTED(ZEND_ASYNC_IS_ACTIVE && ZEND_ASYNC_CURRENT_COROUTINE != GC_G(gc_coroutine))) {
+	if (UNEXPECTED(gc_collect_is_deferred())) {
 
 		if (GC_G(gc_coroutine)) {
 			return 0;

--- a/Zend/zend_gc.c
+++ b/Zend/zend_gc.c
@@ -295,7 +295,7 @@ typedef struct _zend_gc_globals {
 	uint32_t dtor_end;
 	zend_fiber *dtor_fiber;
 	bool dtor_fiber_running;
-	bool adjust_threshold; /* the collection deferred to the GC coroutine came from a full root buffer */
+	bool adjust_threshold; /* a full root buffer asked for a collection that has not run yet */
 	zend_async_scope_t *gc_scope; /* async scope where GC was started */
 	zend_async_scope_t *dtor_scope; /* async scope running destructors */
 	zend_coroutine_t *gc_coroutine; /* coroutine where GC was started */
@@ -543,11 +543,11 @@ static void gc_globals_ctor_ex(zend_gc_globals *gc_globals)
 	gc_globals->dtor_end = 0;
 	gc_globals->dtor_fiber = NULL;
 	gc_globals->dtor_fiber_running = false;
+	gc_globals->adjust_threshold = false;
 
 	gc_globals->gc_scope = NULL;
 	gc_globals->dtor_scope = NULL;
 	gc_globals->gc_coroutine = NULL;
-	gc_globals->adjust_threshold = false;
 	gc_globals->microtask = NULL;
 
 #if GC_BENCH
@@ -674,6 +674,12 @@ static void gc_grow_root_buffer(void)
 	GC_G(buf_size) = new_size;
 }
 
+/* A collection requested now goes to the GC coroutine instead of running inline. */
+static zend_always_inline bool gc_collect_is_deferred(void)
+{
+	return ZEND_ASYNC_IS_ACTIVE && ZEND_ASYNC_CURRENT_COROUTINE != GC_G(gc_coroutine);
+}
+
 /* Adjust the GC activation threshold given the number of nodes collected by the last run */
 static void gc_adjust_threshold(int count)
 {
@@ -705,10 +711,20 @@ static void gc_adjust_threshold(int count)
 	}
 }
 
-/* A collection requested now goes to the GC coroutine instead of running inline. */
-static zend_always_inline bool gc_collect_is_deferred(void)
+/* Adjust the threshold, or record that it is owed when the run has not happened yet.
+ *
+ * A deferred collection is handed to the GC coroutine and reports 0 collected nodes to its
+ * caller. Zero reads as "collected almost nothing", so adjusting on it would step the threshold
+ * up after every full root buffer and never step it back. The record is replayed by
+ * zend_gc_coroutine() from the count that run reports. */
+static void gc_adjust_threshold_or_defer(int count)
 {
-	return ZEND_ASYNC_IS_ACTIVE && ZEND_ASYNC_CURRENT_COROUTINE != GC_G(gc_coroutine);
+	if (gc_collect_is_deferred()) {
+		GC_G(adjust_threshold) = true;
+		return;
+	}
+
+	gc_adjust_threshold(count);
 }
 
 /* Perform a GC run and then add a node as a possible root. */
@@ -721,32 +737,13 @@ static zend_never_inline void ZEND_FASTCALL gc_possible_root_when_full(zend_refc
 	ZEND_ASSERT(GC_INFO(ref) == 0);
 
 	if (GC_G(gc_enabled) && !GC_G(gc_active)) {
-		const bool deferred = gc_collect_is_deferred();
-
-		if (deferred) {
-			/* The run goes to the GC coroutine and this caller is told 0 nodes were collected.
-			 * Adjusting on that 0 raises the threshold by a full step after every full root
-			 * buffer, so the coroutine adjusts instead, from the count it really collected. */
-			GC_G(adjust_threshold) = true;
-		}
-
-		/* A GC coroutine already spawned covers this buffer too, and a second request would
-		 * return at once - a call made for every root buffered until that coroutine runs. */
-		if (!deferred || GC_G(gc_coroutine) == NULL) {
-			GC_ADDREF(ref);
-
-			if (deferred) {
-				gc_collect_cycles();
-			} else {
-				gc_adjust_threshold(gc_collect_cycles());
-			}
-
-			if (UNEXPECTED(GC_DELREF(ref) == 0)) {
-				rc_dtor_func(ref);
-				return;
-			} else if (UNEXPECTED(GC_INFO(ref))) {
-				return;
-			}
+		GC_ADDREF(ref);
+		gc_adjust_threshold_or_defer(gc_collect_cycles());
+		if (UNEXPECTED(GC_DELREF(ref) == 0)) {
+			rc_dtor_func(ref);
+			return;
+		} else if (UNEXPECTED(GC_INFO(ref))) {
+			return;
 		}
 	}
 
@@ -2197,13 +2194,17 @@ static void zend_gc_coroutine(void)
 {
 	GC_TRACE("GC coroutine started");
 
+	const uint32_t runs = GC_G(gc_runs);
 	const int count = zend_gc_collect_cycles();
 
-	/* One run answers every root buffer that filled while it was pending, so one adjustment
-	 * covers them all. */
+	/* One run answers every root buffer that filled while it was pending. A run that found the
+	 * buffer already drained examined nothing, and its 0 measures nothing either. */
 	if (GC_G(adjust_threshold)) {
 		GC_G(adjust_threshold) = false;
-		gc_adjust_threshold(count);
+
+		if (GC_G(gc_runs) != runs) {
+			gc_adjust_threshold(count);
+		}
 	}
 
 	GC_G(gc_coroutine) = NULL;
@@ -2213,16 +2214,6 @@ static void zend_gc_coroutine(void)
 static zend_string* zend_gc_coroutine_info(zend_async_event_t *event)
 {
 	return zend_coroutine_gen_info((zend_coroutine_t *) event, "zend_gc_coroutine");
-}
-
-/* A GC coroutine cancelled before it starts never reaches zend_gc_coroutine(), so the state
- * it would have cleared is cleared here instead. */
-static void gc_coroutine_dispose(zend_coroutine_t *coroutine)
-{
-	if (coroutine == GC_G(gc_coroutine)) {
-		GC_G(gc_coroutine) = NULL;
-		GC_G(adjust_threshold) = false;
-	}
 }
 
 static zend_always_inline zend_coroutine_t* new_gc_coroutine(void)
@@ -2237,7 +2228,6 @@ static zend_always_inline zend_coroutine_t* new_gc_coroutine(void)
 
 	coroutine->internal_entry = zend_gc_coroutine;
 	coroutine->event.info = zend_gc_coroutine_info;
-	coroutine->extended_dispose = gc_coroutine_dispose;
 
 	return coroutine;
 }
@@ -2257,6 +2247,7 @@ static zend_always_inline void start_gc_in_coroutine(void)
 	}
 
 	if (UNEXPECTED(new_gc_coroutine() == NULL)) {
+		GC_G(adjust_threshold) = false;
 		return;
 	}
 }


### PR DESCRIPTION
Fixes true-async/php-async#234. Tests: true-async/php-async#243.

## The defect

In async mode `zend_gc_collect_cycles()` hands the run to the GC coroutine and returns 0 to its caller. `gc_possible_root_when_full()` adjusted the threshold on that 0, and 0 is below `GC_THRESHOLD_TRIGGER`, so every full root buffer raised the threshold by a full step and nothing ever lowered it: 10001, 20001, 30001 and on. Collections then ran further and further apart, the memory amplitude grew with them, and a long-running server reached `memory_limit`.

The second half of the same condition, `num_roots >= gc_threshold`, is true in async mode as well while the collection is pending, so a non-zero count would not have helped either.

## The change

42 lines, of which two land inside upstream functions.

- `gc_possible_root_when_full()` keeps its body and names `gc_adjust_threshold_or_defer()` instead of `gc_adjust_threshold()`. The wrapper records the request when the collection was deferred and adjusts inline when it was not.
- `zend_gc_coroutine()` replays the record from the count its run reports, and only when the run examined something: a collection that finds the root buffer already drained returns 0 without looking at a root, and that 0 is not a measurement.
- A spawn failure clears the record; `gc_reset()` clears it per request.

## Measured

A mini async HTTP server, cyclic garbage per request, 3000 requests:

| | threshold | peak memory |
|---|---|---|
| before | 10001 -> 60001 over the run, 5 collections | 18 -> 36 -> 53 -> 71 -> 89 MB, climbing |
| after | 10001 throughout, 15 collections | 18.21 MB, flat from the second burst on |

The heuristic still works where it should: on a live object graph the threshold climbs 10001 -> 50001 in async mode against 10001 -> 60001 in sync, with identical memory; once the graph is released it walks back down to 10001 and stays there. 100 concurrent producers over 10M cyclic objects: everything collected, peak 40 MB, threshold 10001.

One shape is unchanged and was not addressed: a stretch of code with no suspension point never lets the GC coroutine run, so nothing is collected there — 218 MB in both builds. That is the deferred-collection model, not this bug.

## Tests

`Zend/tests/gc` and every `*gc*` test in `Zend/tests`, `ext/standard`, `ext/opcache`, `ext/spl`: 122 pass, 1 skip, 0 fail. Full extension suite on the patched build: 1171 pass, 0 fail.

Nine tests in true-async/php-async#243. Five fail on this branch's parent; the others hold contracts the fix must not break, and each was checked against the engine change that would have kept it green.

## Reviewed

Four review passes, three of them on one axis each. What they changed here: the first version restructured `gc_possible_root_when_full` and paid a permanent merge conflict in a function upstream edits, for a redundant call it saved; it consumed the record against runs that never examined a root; it left the record set when the spawn failed; and it carried a dispose hook that `extended_dispose` does not reach on every path. The commit history keeps both versions.
