### PR TITLE
async: a vectored write the caller can await

### DIFF
--- a/Zend/zend_async_API.h
+++ b/Zend/zend_async_API.h
@@ -609,6 +609,15 @@ typedef zend_async_io_req_t *(*zend_async_io_write_t)(zend_async_io_t *io, const
  * entry per the mode's contract). */
 #define ZEND_ASYNC_IO_WRITEV_ZSTR  0u
 #define ZEND_ASYNC_IO_WRITEV_IOV   1u
+/* The mode is the low bit of the flag word; the bits above it carry behaviour. */
+#define ZEND_ASYNC_IO_WRITEV_MODE_MASK 1u
+/* Await this write instead of forgetting it. Ownership of the buffers is the
+ * mode's, unchanged. What changes is the completion: the reactor keeps the
+ * request alive and notifies io->event with the request as the result and no
+ * exception, so a caller filtering by request pointer wakes and no sibling
+ * awaiter on the same handle does. The status is on req->transferred and
+ * req->exception, and the caller disposes the request exactly once. */
+#define ZEND_ASYNC_IO_WRITEV_AWAIT (1u << 1)
 typedef zend_async_io_req_t *(*zend_async_io_writev_t)(zend_async_io_t *io,
 		const void *bufs, unsigned nbufs, uint32_t flags,
 		zend_async_io_write_free_cb_t free_cb, void *user_data);
@@ -2930,6 +2939,13 @@ END_EXTERN_C()
 #define ZEND_ASYNC_IO_WRITEV(io, bufs, nbufs) \
 	zend_async_io_writev_fn((io), (const void *)(bufs), (nbufs), \
 			ZEND_ASYNC_IO_WRITEV_ZSTR, NULL, NULL)
+/* Vectored write the caller awaits. `bufs` is a zend_string ** and the reactor
+ * takes one reference per slot, so the buffers outlive a caller that is
+ * cancelled while parked — the reason this exists. Returns NULL when nothing
+ * was submitted, with the references already released unless nbufs was 0. */
+#define ZEND_ASYNC_IO_WRITEV_AWAITED(io, bufs, nbufs) \
+	zend_async_io_writev_fn((io), (const void *)(bufs), (nbufs), \
+			ZEND_ASYNC_IO_WRITEV_ZSTR | ZEND_ASYNC_IO_WRITEV_AWAIT, NULL, NULL)
 /* Fire-and-forget vectored write — plain-iovec mode. `iov` is an array
  * of (base, len) zend_async_buf_t pointing into caller memory; reactor
  * calls free_cb(user_data, io) once on completion or submit failure.

--- a/Zend/zend_async_API.h
+++ b/Zend/zend_async_API.h
@@ -611,12 +611,10 @@ typedef zend_async_io_req_t *(*zend_async_io_write_t)(zend_async_io_t *io, const
 #define ZEND_ASYNC_IO_WRITEV_IOV   1u
 /* The mode is the low bit of the flag word; the bits above it carry behaviour. */
 #define ZEND_ASYNC_IO_WRITEV_MODE_MASK 1u
-/* Await this write instead of forgetting it. Ownership of the buffers is the
- * mode's, unchanged. What changes is the completion: the reactor keeps the
- * request alive and notifies io->event with the request as the result and no
- * exception, so a caller filtering by request pointer wakes and no sibling
- * awaiter on the same handle does. The status is on req->transferred and
- * req->exception, and the caller disposes the request exactly once. */
+/* Await this write. Buffer ownership stays the mode's; only the completion
+ * differs — the request survives it and io->event is notified with the request
+ * as the result and no exception, so siblings on the handle stay asleep. Status
+ * is on req->transferred / req->exception; the caller disposes once. */
 #define ZEND_ASYNC_IO_WRITEV_AWAIT (1u << 1)
 typedef zend_async_io_req_t *(*zend_async_io_writev_t)(zend_async_io_t *io,
 		const void *bufs, unsigned nbufs, uint32_t flags,
@@ -2939,10 +2937,10 @@ END_EXTERN_C()
 #define ZEND_ASYNC_IO_WRITEV(io, bufs, nbufs) \
 	zend_async_io_writev_fn((io), (const void *)(bufs), (nbufs), \
 			ZEND_ASYNC_IO_WRITEV_ZSTR, NULL, NULL)
-/* Vectored write the caller awaits. `bufs` is a zend_string ** and the reactor
- * takes one reference per slot, so the buffers outlive a caller that is
- * cancelled while parked — the reason this exists. Returns NULL when nothing
- * was submitted, with the references already released unless nbufs was 0. */
+/* Vectored write the caller awaits. `bufs` is a zend_string **; the reactor
+ * takes one reference per slot, so the buffers outlive a caller cancelled while
+ * parked. NULL means nothing was submitted — references already released,
+ * unless nbufs was 0. */
 #define ZEND_ASYNC_IO_WRITEV_AWAITED(io, bufs, nbufs) \
 	zend_async_io_writev_fn((io), (const void *)(bufs), (nbufs), \
 			ZEND_ASYNC_IO_WRITEV_ZSTR | ZEND_ASYNC_IO_WRITEV_AWAIT, NULL, NULL)


### PR DESCRIPTION
Needed by true-async/php-async and true-async/server: the HTTP/1 server frees a write buffer that libuv still points at, because the only write that reports its status is also the only one that leaves the buffer with the caller.

Both vectored modes are fire-and-forget — `io_pipe_writev_cb` sends no NOTIFY and its release callback takes no status — so a caller that needs the outcome must use the single-buffer write, keep the buffer, and free it when its own wait ends. Once the waiting coroutine is cancelled that moment arrives before the write completes, and the freed bytes stay in libuv's queue.

`ZEND_ASYNC_IO_WRITEV_AWAIT` marks a vectored write as awaited. Buffer ownership is unchanged — it stays whatever the mode says — and only the completion differs: the request stays alive and `io->event` is notified with the request as the result and **no exception**, so a caller matching by request pointer wakes while sibling awaiters on the same handle do not.

Header only. The `flags` word already existed, so nothing changes signature and `ZEND_ASYNC_IO_WRITEV_ZSTR` / `_IOV` keep their values; `_MODE_MASK` names the bit they occupy. The reactor side is true-async/php-async, the consumer is true-async/server.