### PR TITLE
async: report a failed write on the io handle (ABI 0.26.0)

### DIFF
--- a/Zend/zend_async_API.h
+++ b/Zend/zend_async_API.h
@@ -21,9 +21,9 @@
 #include "zend_globals.h"
 #include "zend_stream.h"
 
-#define ZEND_ASYNC_API "TrueAsync ABI v0.25.0"
+#define ZEND_ASYNC_API "TrueAsync ABI v0.26.0"
 #define ZEND_ASYNC_API_VERSION_MAJOR 0
-#define ZEND_ASYNC_API_VERSION_MINOR 25
+#define ZEND_ASYNC_API_VERSION_MINOR 26
 #define ZEND_ASYNC_API_VERSION_PATCH 0
 
 #define ZEND_ASYNC_API_VERSION_NUMBER \
@@ -122,6 +122,12 @@ typedef enum {
 #define ZEND_ASYNC_IO_APPEND      (1 << 4)
 #define ZEND_ASYNC_IO_PRESERVE_FD (1 << 5)
 #define ZEND_ASYNC_IO_OWNS_FD     (1 << 6) /* reactor owns crt_fd and must close it on dispose */
+/* A write on this handle completed with an error. The reactor sets it and
+ * never clears it, which is the only report a consumer gets for a write it did
+ * not await: the completion of such a write carries no status. It says
+ * nothing about the read side — a peer that shut its write half down keeps
+ * reading. */
+#define ZEND_ASYNC_IO_WRITE_FAILED (1 << 7)
 
 typedef struct _zend_async_io_s zend_async_io_t;
 typedef struct _zend_async_io_req_s zend_async_io_req_t;


### PR DESCRIPTION
A write submitted without an awaiter gets no status of its own: its completion is a `free_cb` taking the handle and the user pointer, nothing else. The consumer was left to infer the failure from the read side — and there a peer that merely shut its write half down looks exactly like one that is gone.

`ZEND_ASYNC_IO_WRITE_FAILED` (bit 7, the first free one) is that report. The reactor sets it on the handle when a write completes with an error and never clears it. It says nothing about the read side, which is the point: a half-closed peer keeps reading.

Why the read side cannot stand in for it: the kernel hands `so_error` to whichever syscall asks first, and with a saturated outbound queue that is the write. Measured on bare sockets after an RST — `write -> ECONNRESET`, `write -> EPIPE`, `read -> b''`: the read behind the failing write returns a clean EOF and reports nothing.

Consumers: php-async sets the flag (true-async/php-async, branch `write-failed-state-bit`), and true-async/server reads it to keep a half-closed peer's response alive while still answering 499 to one that is gone (true-async/server#249). Both are guarded, so neither needs this to land first in order to build.

ABI 0.25.0 → 0.26.0: additive, no signature or layout change.