### PR TITLE
streams: close a listening socket at once on Windows

### DIFF
--- a/main/streams/xp_socket.c
+++ b/main/streams/xp_socket.c
@@ -245,6 +245,22 @@ static ssize_t php_sockop_read(php_stream *stream, char *buf, size_t count)
 }
 
 
+#ifdef PHP_WIN32
+/* Whether the socket is in the listening state. Returns false when the state
+ * cannot be read, which keeps the caller on its existing path. */
+static bool php_sockop_is_listening(php_socket_t socket)
+{
+	int accepting = 0;
+	socklen_t accepting_len = sizeof(accepting);
+
+	if (getsockopt(socket, SOL_SOCKET, SO_ACCEPTCONN, (char *) &accepting, &accepting_len) != 0) {
+		return false;
+	}
+
+	return accepting != 0;
+}
+#endif
+
 static int php_sockop_close(php_stream *stream, int close_handle)
 {
 	php_netstream_data_t *sock = (php_netstream_data_t*)stream->abstract;
@@ -264,22 +280,31 @@ static int php_sockop_close(php_stream *stream, int close_handle)
 #endif
 		if (sock->socket != SOCK_ERR) {
 #ifdef PHP_WIN32
-			/* prevent more data from coming in */
-			shutdown(sock->socket, SHUT_RD);
+			/* A listening socket carries no peer data to flush, and the await
+			 * below would wait for a writability that never arrives. Worse,
+			 * the poll event it creates hands the descriptor to the event loop,
+			 * so the real closesocket() lands a loop turn later and the port
+			 * stays bound — long enough for the next bind() to be refused. */
+			const bool is_listening = php_sockop_is_listening(sock->socket);
 
-			/* try to make sure that the OS sends all data before we close the connection.
-			 * Essentially, we are waiting for the socket to become writeable, which means
-			 * that all pending data has been sent.
-			 * We use a small timeout which should encourage the OS to send the data,
-			 * but at the same time avoid hanging indefinitely.
-			 * */
-			if (ZEND_ASYNC_IS_ACTIVE && !sock->is_sync) {
-				struct timeval tv = {0, 500000}; // 500ms
-				network_async_await_stream_socket(sock, POLLOUT, &tv);
-			} else {
-				do {
-					n = php_pollfd_for_ms(sock->socket, POLLOUT, 500);
-				} while (n == -1 && php_socket_errno() == EINTR);
+			if (!is_listening) {
+				/* prevent more data from coming in */
+				shutdown(sock->socket, SHUT_RD);
+
+				/* try to make sure that the OS sends all data before we close the connection.
+				 * Essentially, we are waiting for the socket to become writeable, which means
+				 * that all pending data has been sent.
+				 * We use a small timeout which should encourage the OS to send the data,
+				 * but at the same time avoid hanging indefinitely.
+				 * */
+				if (ZEND_ASYNC_IS_ACTIVE && !sock->is_sync) {
+					struct timeval tv = {0, 500000}; // 500ms
+					network_async_await_stream_socket(sock, POLLOUT, &tv);
+				} else {
+					do {
+						n = php_pollfd_for_ms(sock->socket, POLLOUT, 500);
+					} while (n == -1 && php_socket_errno() == EINTR);
+				}
 			}
 #endif
 


### PR DESCRIPTION
`php_sockop_close` waits up to 500 ms for the socket to become writable, so
that the OS flushes whatever is still queued. A listening socket has no peer
and never becomes writable, so that wait always runs its full 500 ms — and
under the async reactor it takes the `network_async_await_stream_socket`
branch, which creates a `poll_event`. A non-NULL `poll_event` then routes the
descriptor to `ZEND_ASYNC_EVENT_SET_CLOSE_FD` instead of `closesocket()`, so
the socket really closes a loop turn later, in `libuv_close_poll_handle_cb`.

The port therefore stays bound after `fclose()` has returned. Anything that
binds it next — libuv asks for no `SO_REUSEADDR` on Windows — is refused with
`EADDRINUSE`.

Measured on `ext/http_server`'s phpt suite, which allocates ports by opening a
listening socket, closing it and reusing the number:

| | passed | failed |
|---|---|---|
| before | 107 | 53 |
| after | 139 | 22 |

`fclose()` on a listening socket drops from 508 ms to 0 ms. The remaining 22
failures are unrelated (path validation, HTTP/2 stream cancel, TLS telemetry).

Connected sockets keep the flush wait unchanged — that is where pending data
and pending IOCP operations are real. The state is read with
`getsockopt(SO_ACCEPTCONN)`, and a failed read keeps the old path.
