### PR TITLE
docs(async): state what ZEND_ASYNC_IO_PRESERVE_FD reaches

### DIFF
--- a/Zend/zend_async_API.h
+++ b/Zend/zend_async_API.h
@@ -120,6 +120,12 @@ typedef enum {
 #define ZEND_ASYNC_IO_CLOSED      (1 << 2)
 #define ZEND_ASYNC_IO_EOF         (1 << 3)
 #define ZEND_ASYNC_IO_APPEND      (1 << 4)
+/* Keep the descriptor when the io is disposed. It reaches only a descriptor the
+ * reactor closes on its own account — a file, or a copy the reactor made — so a
+ * descriptor a stream handle adopts is outside it: the backend owns such a
+ * handle and closes what it adopted, this flag or not. A caller that must keep
+ * a socket alive past the io therefore cannot; it hands the socket over, or
+ * hands over a copy of its own and lives with two file descriptions. */
 #define ZEND_ASYNC_IO_PRESERVE_FD (1 << 5)
 #define ZEND_ASYNC_IO_OWNS_FD     (1 << 6) /* reactor owns crt_fd and must close it on dispose */
 /* A write on this handle completed with an error. The reactor sets it and


### PR DESCRIPTION
`ZEND_ASYNC_IO_PRESERVE_FD` carried no prose, and its real contract turned out to be narrower than every caller assumed: it reaches only a descriptor the reactor closes on its own account. A descriptor adopted by a libuv stream handle is outside it — the handle owns the descriptor and `uv_close` closes it whatever the flag says.

That gap cost a real defect in true-async/server (issue #293): a log sink passed the flag for a TCP socket, kept the PHP stream on the strength of it, and the socket was closed twice — WSAENOTSOCK on Windows, a silent EBADF on POSIX, which is the worse half because the descriptor number is reused and the late close lands on another connection.

Header comment only, no behaviour change.