### PR TITLE
Let a curl upload's read state own what it points at

### DIFF
--- a/ext/curl/curl_async.c
+++ b/ext/curl/curl_async.c
@@ -1385,10 +1385,6 @@ static void curl_async_read_complete(
 				state->file.io = NULL;
 			}
 
-			if ((state->flags & CURL_READ_OWNS_FD) && state->file.fd >= 0) {
-				close(state->file.fd);
-			}
-
 			/* A mime state outlives its event: libcurl frees the part, and
 			 * curl_async_free_cb() frees the state with it. Everything this
 			 * state held is released above, so the free_cb finds nothing left
@@ -1470,9 +1466,6 @@ void curl_async_read_state_free(curl_async_read_state_t *state)
 		if (state->file.pending != NULL) {
 			state->file.pending->dispose(state->file.pending);
 			state->file.pending = NULL;
-		}
-		if ((state->flags & CURL_READ_OWNS_FD) && state->file.fd >= 0) {
-			close(state->file.fd);
 		}
 	} else if (state->source == CURL_READ_CALLBACK) {
 		if (state->callback.result != NULL) {

--- a/ext/curl/curl_async.c
+++ b/ext/curl/curl_async.c
@@ -328,6 +328,24 @@ static bool curl_async_event_stop(zend_async_event_t *event)
 	curl_event->write_state = NULL;
 	curl_event->header_write_state = NULL;
 
+	/* A CURLFile part keeps a read state of its own, hung on the mime callback
+	 * argument rather than on the handle, and the handle owns those arguments.
+	 * Without this the state would still name an event that is about to be
+	 * freed, and its completion would read through it. The state itself belongs
+	 * to curl_async_free_cb(), which libcurl calls when it releases the part. */
+	if (curl_event->ch->to_free != NULL) {
+		zend_llist_position pos;
+		mime_data_cb_arg_t **cb_arg_p;
+
+		for (cb_arg_p = (mime_data_cb_arg_t **) zend_llist_get_first_ex(&curl_event->ch->to_free->stream, &pos);
+			 cb_arg_p != NULL;
+			 cb_arg_p = (mime_data_cb_arg_t **) zend_llist_get_next_ex(&curl_event->ch->to_free->stream, &pos)) {
+			if (*cb_arg_p != NULL && (*cb_arg_p)->async_state != NULL) {
+				(*cb_arg_p)->async_state->event = NULL;
+			}
+		}
+	}
+
 	/* Cancel any pending async read (state lives on ch, not on event) */
 	if (curl_event->ch->async_read_state != NULL) {
 		curl_async_read_state_t *rs = curl_event->ch->async_read_state;
@@ -1340,8 +1358,12 @@ static void curl_async_read_complete(
 	/* Event was cancelled — free orphaned state and bail */
 	if (state->event == NULL) {
 		if (state->source == CURL_READ_FILE) {
+			/* Each field is cleared as it is released: a mime state is not freed
+			 * here, and its owner walks the same fields when libcurl lets go of
+			 * the part. */
 			if (state->file.req != NULL) {
 				state->file.req->dispose(state->file.req);
+				state->file.req = NULL;
 			}
 
 			/* The request this call was given: it left `pending` above, and the
@@ -1352,14 +1374,27 @@ static void curl_async_read_complete(
 			}
 
 			/* The subscription outlives the state it names, and the next
-			 * notification on this descriptor would read through it. */
+			 * notification on this descriptor would read through it. Dropping it
+			 * releases the reference it held; the notify in progress holds one of
+			 * its own, so the io survives until this call returns. */
 			if (state->file.io != NULL && state->file.io_cb != NULL) {
 				io_cb->state = NULL;
 				state->file.io->event.del_callback(&state->file.io->event, state->file.io_cb);
+				state->file.io->event.dispose(&state->file.io->event);
+				state->file.io_cb = NULL;
+				state->file.io = NULL;
 			}
 
 			if ((state->flags & CURL_READ_OWNS_FD) && state->file.fd >= 0) {
 				close(state->file.fd);
+			}
+
+			/* A mime state outlives its event: libcurl frees the part, and
+			 * curl_async_free_cb() frees the state with it. Everything this
+			 * state held is released above, so the free_cb finds nothing left
+			 * to do but the free itself. */
+			if (state->flags & CURL_READ_MIME) {
+				return;
 			}
 		}
 		efree(state);
@@ -1414,16 +1449,18 @@ finish:
 void curl_async_read_state_free(curl_async_read_state_t *state)
 {
 	if (state->source == CURL_READ_FILE) {
-		/* IO is borrowed from the stream, not owned by curl.
-		 * The stream (plain_wrapper) is responsible for close + dispose.
-		 * But our subscription on io->event MUST be removed here — otherwise
-		 * a later io.event notification (e.g. stream close) fires the callback
-		 * on freed state → UAF / zend_mm heap corruption. */
+		/* The stream opened the io and closes it, but the close disposes it too,
+		 * and that can happen while this subscription still stands. The
+		 * subscription holds a reference for exactly that window: removing it
+		 * here and releasing the reference is what frees the io, and leaving it
+		 * would fire the callback on a freed state. */
 		if (state->file.io != NULL && state->file.io_cb != NULL) {
 			state->file.io->event.del_callback(&state->file.io->event,
 			                                   state->file.io_cb);
 			state->file.io_cb = NULL;
+			state->file.io->event.dispose(&state->file.io->event);
 		}
+
 		state->file.io = NULL;
 		if (state->file.req != NULL) {
 			state->file.req->dispose(state->file.req);
@@ -1860,6 +1897,7 @@ size_t curl_async_read_cb(char *buffer, const size_t size, const size_t nitems, 
 			if (io != NULL) {
 				cb_arg->async_state = ecalloc(1, sizeof(curl_async_read_state_t));
 				cb_arg->async_state->source = CURL_READ_FILE;
+				cb_arg->async_state->flags = CURL_READ_MIME;
 				cb_arg->async_state->curl = cb_arg->curl;
 				cb_arg->async_state->event = curl_event;
 				cb_arg->async_state->file.io = io;
@@ -1876,8 +1914,16 @@ size_t curl_async_read_cb(char *buffer, const size_t size, const size_t nitems, 
 					ZEND_ASYNC_EVENT_CALLBACK_EX(curl_async_read_complete,
 						sizeof(curl_async_read_io_callback_t));
 				io_cb->state = cb_arg->async_state;
-				cb_arg->async_state->file.io_cb = &io_cb->base;
-				io->event.add_callback(&io->event, &io_cb->base);
+
+				if (io->event.add_callback(&io->event, &io_cb->base)) {
+					/* The io belongs to the stream, and closing the stream disposes
+					 * it. This subscription outlives that close, so it holds a
+					 * reference of its own; curl_async_read_state_free() drops it. */
+					ZEND_ASYNC_EVENT_ADD_REF(&io->event);
+					cb_arg->async_state->file.io_cb = &io_cb->base;
+				} else {
+					io_cb->base.dispose(&io_cb->base, NULL);
+				}
 #endif
 			}
 		}
@@ -1970,8 +2016,15 @@ size_t curl_async_read_dispatch(php_curl *ch, char *buffer, const size_t request
 							ZEND_ASYNC_EVENT_CALLBACK_EX(curl_async_read_complete,
 								sizeof(curl_async_read_io_callback_t));
 						io_cb->state = ch->async_read_state;
-						ch->async_read_state->file.io_cb = &io_cb->base;
-						io->event.add_callback(&io->event, &io_cb->base);
+
+						if (io->event.add_callback(&io->event, &io_cb->base)) {
+							/* Same reference as the CURLFile path above: the stream
+							 * may close while this read is parked. */
+							ZEND_ASYNC_EVENT_ADD_REF(&io->event);
+							ch->async_read_state->file.io_cb = &io_cb->base;
+						} else {
+							io_cb->base.dispose(&io_cb->base, NULL);
+						}
 					}
 				}
 			}

--- a/ext/curl/curl_async.h
+++ b/ext/curl/curl_async.h
@@ -79,6 +79,7 @@ static zend_always_inline void curl_async_event_set_callback_exception(
 #define CURL_READ_ABORT    0x10   /* callback returned CURL_READFUNC_ABORT */
 #define CURL_READ_PAUSE    0x20   /* callback returned CURL_READFUNC_PAUSE */
 #define CURL_READ_CLOSED   0x40   /* the IO handle was closed under this state */
+#define CURL_READ_MIME     0x80   /* the mime callback argument owns this state */
 
 struct curl_async_read_state_s {
 	CURL *curl;                     /* back-ref for curl_easy_pause */

--- a/ext/curl/curl_async.h
+++ b/ext/curl/curl_async.h
@@ -75,7 +75,6 @@ static zend_always_inline void curl_async_event_set_callback_exception(
 #define CURL_READ_EOF      0x01
 #define CURL_READ_ERROR    0x02
 #define CURL_READ_PENDING  0x04
-#define CURL_READ_OWNS_FD  0x08   /* fd was opened by us and must be closed */
 #define CURL_READ_ABORT    0x10   /* callback returned CURL_READFUNC_ABORT */
 #define CURL_READ_PAUSE    0x20   /* callback returned CURL_READFUNC_PAUSE */
 #define CURL_READ_CLOSED   0x40   /* the IO handle was closed under this state */
@@ -97,7 +96,9 @@ struct curl_async_read_state_s {
 			 * for any other request is not this state's to take. NULL while
 			 * nothing is in flight. */
 			zend_async_io_req_t *pending;
-			int fd;                     /* >= 0: owned (CURLFile), -1: stream owns */
+			/* Borrowed from the stream, which closes it. -1 when the stream
+			 * gave none, and then only the io path is usable. */
+			int fd;
 		} file;
 		struct {
 			zend_string *result;        /* string returned by PHP callback */


### PR DESCRIPTION
Fixes true-async/php-async#295 and true-async/php-async#294.

## #295 — the subscription counted nothing

`curl_async_read` parks on the stream's `zend_async_io_t` and keeps a raw pointer
to it. Neither the subscription nor the state took a reference:
`zend_async_callbacks_push` counts the callback, and the stream's own `ref_count`
in `main/streams/plain_wrapper.c` rises only around a parked coroutine. So an
`fclose()` between two of curl's reads found `ref_count` at zero, `php_stdiop_close`
disposed the io, and `curl_async_read_state_free()` then removed its subscription
through the freed block.

Reproduced under ASAN, `USE_ZEND_ALLOC=0` (the io is freed through ZendMM, so the
sanitizer sees it only with the allocator out of the way):

```
==6146==ERROR: AddressSanitizer: heap-use-after-free
    #0 curl_async_read_state_free ext/curl/curl_async.c:1425
    #1 curl_async_event_stop ext/curl/curl_async.c:337
  freed by thread T0 here:
    #3 libuv_io_event_dispose ext/async/libuv_reactor.c:4727
    #4 php_stdiop_close main/streams/plain_wrapper.c:962
    #6 zif_fclose ext/standard/file.c:779
```

The subscription now holds a reference of its own, taken where the callback is
added and released where it is removed — the shape the reactor already uses for
an io it names (`libuv_reactor.c:6222` and `:5285`), and safe because
`libuv_io_event_dispose` is refcount-aware. It is keyed on `file.io_cb` rather
than on `file.io`: `file.io` is assigned outside the `LIBCURL_VERSION_NUM >= 0x080B01`
guard and `file.io_cb` inside it, while `config.m4` admits libcurl from 7.87.0, so
a build in that range has the pointer without the subscription and must not
release a reference it never took.

The `add_callback` result is checked at both subscription sites. A failure used to
leave a callback allocated and named by a state that would never hear from it.

## #294 — a CURLFile read state was out of reach from its event

A `CURLFile` part carries a second read state, hung on the mime callback argument,
and `curl_async_event_stop()` knew only `ch->async_read_state`. That state went on
naming an event about to be freed.

The handle owns the mime arguments — `ch->to_free->stream` is a `zend_llist` of
`mime_data_cb_arg_t *` — so `stop()` walks them and severs the back-link. Freeing
stays with `curl_async_free_cb()`, which libcurl calls when it releases the part:
the completion of a read that outlives its event releases the request and the
subscription and leaves the state alone, marked by the new `CURL_READ_MIME` flag,
and every field it releases is cleared, so the `free_cb` finds nothing to release
twice.

**This half has no test.** The dangling pointer itself was observed directly, with
a read in flight, by instrumenting the event's destructor:

```
TASDBG mime-async    st=0x506000024c80
TASDBG dtor-dangling st=0x506000024c80 ev=0x50f000025fc0 this=0x50f000025fc0 pending=1
```

`ev` is the event the state names and `this` the event being destroyed. What no
script produced is a completion landing in the window between that destructor and
the `free_cb`: ten attempts, including a fifo source (useless for `CURLFile` — the
part's length comes from `stat`, which is 0 for a fifo, so the body is sent empty),
a single-thread `UV_THREADPOOL_SIZE` with eight concurrent uploads, and 160 handle
removals at varying points of the upload. The fix is by construction.

## The dead flag

`CURL_READ_OWNS_FD` guarded two `close()` calls and was set nowhere: `60fdf5a5fc7`
deleted its only assignment along with the raw `VCWD_OPEN` it belonged to. Every
descriptor a read state holds comes from `php_stream_cast()` on a stream somebody
else closes, so setting the flag again would close a number another `open()` may
already have taken. Removed with both branches, in its own commit.

## Checks

- `tests/curl/071-upload_stream_closed_mid_read.phpt` (php-async, sent separately):
  heap-use-after-free under ASAN on a rebuild of this tree with the first commit
  reverted, green with it.
- `ext/async/tests/curl` under ASAN — 68 passed, 0 failed.
- `ext/async/tests` — 1194 passed, 0 failed. `fuzzy-tests/_generated` — 724 passed,
  0 failed.
- `ext/curl/tests` under ASAN — 168 passed, 4 failed: `curl_writefunction_throws_abort`,
  `curl_readfunction_throws_abort`, `curl_headerfunction_throws_abort` and
  `curl_curlfile_seek`. All four fail the same way on a build of this tree without
  these commits.
- No leaks reported with `detect_leaks=1` on either probe.