### PR TITLE
Three curl defects the php-src suite was already reporting

### DIFF
--- a/ext/curl/curl_async.c
+++ b/ext/curl/curl_async.c
@@ -2033,6 +2033,14 @@ size_t curl_async_read_dispatch(php_curl *ch, char *buffer, const size_t request
 			if (ch->async_read_state->file.fd < 0) {
 				curl_async_read_state_free(ch->async_read_state);
 				ch->async_read_state = NULL;
+
+				/* No source named at all: CURLOPT_READFUNCTION reset to null with no
+				 * CURLOPT_INFILE behind it. Nothing to send is an empty body, not a
+				 * failed transfer. */
+				if (Z_ISUNDEF(read_handler->stream) && read_handler->fp == NULL) {
+					return 0;
+				}
+
 				return CURL_READFUNC_ABORT;
 			}
 

--- a/ext/curl/curl_async.c
+++ b/ext/curl/curl_async.c
@@ -1922,6 +1922,43 @@ size_t curl_async_read_cb(char *buffer, const size_t size, const size_t nitems, 
 }
 
 /**
+ * @brief Seek callback for a CURLFile part.
+ *
+ * libcurl rewinds the body to replay it, after a redirect or an authentication
+ * challenge. Answers CURL_SEEKFUNC_CANTSEEK when the part cannot be replayed,
+ * which makes libcurl fail the transfer rather than send it truncated.
+ */
+int curl_async_seek_cb(void *arg, const curl_off_t offset, const int origin)
+{
+	mime_data_cb_arg_t *cb_arg = (mime_data_cb_arg_t *) arg;
+
+	/* Nothing read yet: the first read opens at the beginning anyway. */
+	if (cb_arg->stream == NULL) {
+		return origin == SEEK_SET && offset == 0 ? CURL_SEEKFUNC_OK : CURL_SEEKFUNC_CANTSEEK;
+	}
+
+	if (cb_arg->async_state != NULL) {
+		curl_async_read_state_t *state = cb_arg->async_state;
+
+		/* A read in flight will land at the position being left. */
+		if (state->flags & CURL_READ_PENDING) {
+			return CURL_SEEKFUNC_CANTSEEK;
+		}
+
+		/* One that finished holds bytes from that position. */
+		if (state->file.req != NULL) {
+			state->file.req->dispose(state->file.req);
+			state->file.req = NULL;
+		}
+
+		state->flags &= ~(CURL_READ_EOF | CURL_READ_ERROR | CURL_READ_ABORT);
+	}
+
+	return php_stream_seek(cb_arg->stream, offset, origin) == SUCCESS
+			? CURL_SEEKFUNC_OK : CURL_SEEKFUNC_CANTSEEK;
+}
+
+/**
  * @brief Free callback for async CURLFile state.
  *
  * Called by libcurl when the mime part is freed. Cleans up the async IO

--- a/ext/curl/curl_async.c
+++ b/ext/curl/curl_async.c
@@ -95,13 +95,7 @@ static inline bool curl_has_pending_async_io(const curl_async_event_t *curl_even
 			&& (curl_event->ch->async_read_state->flags & CURL_READ_PENDING));
 }
 
-/**
- * @brief The code a finished transfer reports.
- *
- * A user callback that threw aborts the transfer whatever libcurl made of it:
- * the exception travels to the caller with the notification, and curl_errno()
- * has to say the same thing.
- */
+/** @brief The code a finished transfer reports: a callback that threw decides it. */
 static zend_always_inline CURLcode curl_async_transfer_result(
 	const curl_async_event_t *curl_event, const CURLcode result)
 {
@@ -736,9 +730,8 @@ CURLcode curl_async_perform(php_curl *ch)
 	// Suspend coroutine until curl completes
 	const bool resumed = ZEND_ASYNC_SUSPEND();
 
-	/* The waker carries the code the completion decided. A coroutine woken by an
-	 * exception carries none, and the callback that threw left its own code on the
-	 * handle. Neither is read from the event, which may already be disposed. */
+	/* Not from the event, which the notification may already have disposed: the
+	 * waker carries the completion's code, the handle a throwing callback's. */
 	CURLcode result = EXPECTED(resumed) ? CURLE_OK : CURLE_ABORTED_BY_CALLBACK;
 
 	if (coroutine->waker != NULL && Z_TYPE(coroutine->waker->result) == IS_LONG) {
@@ -1938,17 +1931,15 @@ size_t curl_async_read_cb(char *buffer, const size_t size, const size_t nitems, 
 }
 
 /**
- * @brief Seek callback for a CURLFile part.
+ * @brief Seek callback for a CURLFile part, called when libcurl replays the body.
  *
- * libcurl rewinds the body to replay it, after a redirect or an authentication
- * challenge. Answers CURL_SEEKFUNC_CANTSEEK when the part cannot be replayed,
- * which makes libcurl fail the transfer rather than send it truncated.
+ * CURL_SEEKFUNC_CANTSEEK fails the transfer rather than send it truncated.
  */
 int curl_async_seek_cb(void *arg, const curl_off_t offset, const int origin)
 {
 	mime_data_cb_arg_t *cb_arg = (mime_data_cb_arg_t *) arg;
 
-	/* Nothing read yet: the first read opens at the beginning anyway. */
+	/* Nothing read yet: the first read opens at the beginning. */
 	if (cb_arg->stream == NULL) {
 		return origin == SEEK_SET && offset == 0 ? CURL_SEEKFUNC_OK : CURL_SEEKFUNC_CANTSEEK;
 	}
@@ -1956,12 +1947,12 @@ int curl_async_seek_cb(void *arg, const curl_off_t offset, const int origin)
 	if (cb_arg->async_state != NULL) {
 		curl_async_read_state_t *state = cb_arg->async_state;
 
-		/* A read in flight will land at the position being left. */
+		/* In flight: it would land at the position being left. */
 		if (state->flags & CURL_READ_PENDING) {
 			return CURL_SEEKFUNC_CANTSEEK;
 		}
 
-		/* One that finished holds bytes from that position. */
+		/* Finished: it holds bytes from that position. */
 		if (state->file.req != NULL) {
 			state->file.req->dispose(state->file.req);
 			state->file.req = NULL;
@@ -2034,8 +2025,7 @@ size_t curl_async_read_dispatch(php_curl *ch, char *buffer, const size_t request
 				curl_async_read_state_free(ch->async_read_state);
 				ch->async_read_state = NULL;
 
-				/* No source named at all: CURLOPT_READFUNCTION reset to null with no
-				 * CURLOPT_INFILE behind it. Nothing to send is an empty body, not a
+				/* No source named at all. Nothing to send is an empty body, not a
 				 * failed transfer. */
 				if (Z_ISUNDEF(read_handler->stream) && read_handler->fp == NULL) {
 					return 0;

--- a/ext/curl/curl_async.c
+++ b/ext/curl/curl_async.c
@@ -95,6 +95,19 @@ static inline bool curl_has_pending_async_io(const curl_async_event_t *curl_even
 			&& (curl_event->ch->async_read_state->flags & CURL_READ_PENDING));
 }
 
+/**
+ * @brief The code a finished transfer reports.
+ *
+ * A user callback that threw aborts the transfer whatever libcurl made of it:
+ * the exception travels to the caller with the notification, and curl_errno()
+ * has to say the same thing.
+ */
+static zend_always_inline CURLcode curl_async_transfer_result(
+	const curl_async_event_t *curl_event, const CURLcode result)
+{
+	return curl_event->callback_error != CURLE_OK ? curl_event->callback_error : result;
+}
+
 static void process_curl_completed_handles(void)
 {
 	CURLMsg *msg;
@@ -123,7 +136,7 @@ static void process_curl_completed_handles(void)
 			curl_multi_remove_handle(curl_multi_handle, msg->easy_handle);
 
 			zval result;
-			ZVAL_LONG(&result, msg->data.result);
+			ZVAL_LONG(&result, curl_async_transfer_result(curl_event, msg->data.result));
 			ZEND_ASYNC_EVENT_SET_ZVAL_RESULT(&curl_event->base);
 			/* Stop BEFORE notify — notify may trigger dispose/dtor */
 			curl_event->base.stop(&curl_event->base);
@@ -143,7 +156,7 @@ static void process_curl_completed_handles(void)
 			curl_event->curl = NULL;
 
 			zval result;
-			ZVAL_LONG(&result, CURLE_ABORTED_BY_CALLBACK);
+			ZVAL_LONG(&result, curl_async_transfer_result(curl_event, CURLE_ABORTED_BY_CALLBACK));
 			ZEND_ASYNC_EVENT_SET_ZVAL_RESULT(&curl_event->base);
 			curl_event->base.stop(&curl_event->base);
 			ZEND_ASYNC_CALLBACKS_NOTIFY(&curl_event->base, &result, curl_event->callback_exception);
@@ -721,15 +734,17 @@ CURLcode curl_async_perform(php_curl *ch)
 	}
 
 	// Suspend coroutine until curl completes
-	if (UNEXPECTED(false == ZEND_ASYNC_SUSPEND())) {
-		ZEND_ASYNC_WAKER_DESTROY(coroutine);
-		return CURLE_ABORTED_BY_CALLBACK;
-	}
+	const bool resumed = ZEND_ASYNC_SUSPEND();
 
-	// Get result from waker
-	CURLcode result = CURLE_OK;
+	/* The waker carries the code the completion decided. A coroutine woken by an
+	 * exception carries none, and the callback that threw left its own code on the
+	 * handle. Neither is read from the event, which may already be disposed. */
+	CURLcode result = EXPECTED(resumed) ? CURLE_OK : CURLE_ABORTED_BY_CALLBACK;
+
 	if (coroutine->waker != NULL && Z_TYPE(coroutine->waker->result) == IS_LONG) {
 		result = (CURLcode) Z_LVAL(coroutine->waker->result);
+	} else if (!resumed && ch->err.no != CURLE_OK) {
+		result = (CURLcode) ch->err.no;
 	}
 
 	ZEND_ASYNC_WAKER_DESTROY(coroutine);
@@ -1135,6 +1150,7 @@ CURLMcode curl_async_multi_perform(php_curlm * curl_m, int *running_handles)
 			if (event->callback_exception != NULL) {
 				zend_object *const exception = event->callback_exception;
 				event->callback_exception = NULL;
+				event->callback_error = CURLE_OK;
 
 				zval exception_zv;
 				ZVAL_OBJ(&exception_zv, exception);
@@ -1508,7 +1524,7 @@ static void curl_async_read_callback_complete(
 		 * Store it on curl_event to forward to the waiting coroutine. */
 		ZEND_ASYNC_EVENT_SET_EXCEPTION_HANDLED(event);
 		GC_ADDREF(exception);
-		curl_async_event_set_callback_exception(curl_event, exception);
+		curl_async_event_set_callback_exception(curl_event, exception, CURLE_ABORTED_BY_CALLBACK);
 		state->flags |= CURL_READ_ERROR;
 	} else {
 		zend_coroutine_t * const coro = (zend_coroutine_t *) event;
@@ -1533,7 +1549,7 @@ static void curl_async_read_callback_complete(
 				zend_object *ex = EG(exception);
 				GC_ADDREF(ex);
 				zend_clear_exception();
-				curl_async_event_set_callback_exception(curl_event, ex);
+				curl_async_event_set_callback_exception(curl_event, ex, CURLE_ABORTED_BY_CALLBACK);
 				state->flags |= CURL_READ_ERROR;
 			}
 		} else {
@@ -1661,7 +1677,7 @@ static size_t curl_async_read_callback_sync(
 		if (curl_event != NULL) {
 			zend_object *ex = EG(exception);
 			GC_ADDREF(ex);
-			curl_async_event_set_callback_exception(curl_event, ex);
+			curl_async_event_set_callback_exception(curl_event, ex, CURLE_ABORTED_BY_CALLBACK);
 			zend_clear_exception();
 		}
 		zval_ptr_dtor(&retval);
@@ -1688,7 +1704,7 @@ static size_t curl_async_read_callback_sync(
 				zend_object *ex = EG(exception);
 				GC_ADDREF(ex);
 				zend_clear_exception();
-				curl_async_event_set_callback_exception(state->event, ex);
+				curl_async_event_set_callback_exception(state->event, ex, CURLE_ABORTED_BY_CALLBACK);
 				state->flags |= CURL_READ_ERROR;
 				length = CURL_READFUNC_ABORT;
 			}
@@ -2102,7 +2118,7 @@ static void curl_async_write_finish_deferred(curl_async_event_t *curl_event)
 	}
 
 	zval done_result;
-	ZVAL_LONG(&done_result, curl_event->done_result);
+	ZVAL_LONG(&done_result, curl_async_transfer_result(curl_event, curl_event->done_result));
 	ZEND_ASYNC_EVENT_SET_ZVAL_RESULT(&curl_event->base);
 	/* Stop BEFORE notify — notify may trigger dispose/dtor */
 	curl_event->base.stop(&curl_event->base);
@@ -2176,7 +2192,7 @@ static void curl_async_write_user_complete(
 		 * Store it on curl_event to forward to the waiting coroutine. */
 		ZEND_ASYNC_EVENT_SET_EXCEPTION_HANDLED(event);
 		GC_ADDREF(exception);
-		curl_async_event_set_callback_exception(curl_event, exception);
+		curl_async_event_set_callback_exception(curl_event, exception, CURLE_WRITE_ERROR);
 		SAVE_CURL_ERROR(curl_event->ch, CURLE_WRITE_ERROR);
 		state->has_pending_result = true;
 		state->pending_result = (size_t) -1;
@@ -2224,7 +2240,7 @@ static void curl_async_write_user_complete(
 				curl_multi_remove_handle(curl_multi_handle, curl_event->curl);
 			}
 			zval done_result;
-			ZVAL_LONG(&done_result, curl_event->done_result);
+			ZVAL_LONG(&done_result, curl_async_transfer_result(curl_event, curl_event->done_result));
 			ZEND_ASYNC_EVENT_SET_ZVAL_RESULT(&curl_event->base);
 			curl_event->base.stop(&curl_event->base);
 			ZEND_ASYNC_CALLBACKS_NOTIFY(&curl_event->base, &done_result, curl_event->callback_exception);
@@ -2301,7 +2317,7 @@ size_t curl_async_write_user(char *data, const size_t size, const size_t nmemb, 
 			if (curl_event != NULL) {
 				zend_object *ex = EG(exception);
 				GC_ADDREF(ex);
-				curl_async_event_set_callback_exception(curl_event, ex);
+				curl_async_event_set_callback_exception(curl_event, ex, CURLE_WRITE_ERROR);
 				zend_clear_exception();
 			}
 			SAVE_CURL_ERROR(ch, CURLE_WRITE_ERROR);

--- a/ext/curl/curl_async.h
+++ b/ext/curl/curl_async.h
@@ -54,7 +54,7 @@ typedef struct curl_async_event_s {
 	curl_async_write_state_t *write_state;        /* heap-allocated, NULL until first async write */
 	curl_async_write_state_t *header_write_state; /* same, for header writes */
 	zend_object *callback_exception;       /* exception from user callback, forwarded on completion */
-	CURLcode callback_error;               /* code that callback would have made libcurl report */
+	CURLcode callback_error;               /* what the callback would have made libcurl report */
 } curl_async_event_t;
 
 /* Store a callback exception on the event, chaining via "previous" if one
@@ -66,15 +66,13 @@ static zend_always_inline void curl_async_event_set_callback_exception(
 		zend_exception_set_previous(exception, event->callback_exception);
 	}
 	event->callback_exception = exception;
-	/* The transfer reports what the callback would have made libcurl report: a
-	 * write or header callback answers CURLE_WRITE_ERROR, a read one
-	 * CURLE_ABORTED_BY_CALLBACK. The first to throw decides. */
+	/* The first callback to throw decides the code. */
 	if (event->callback_error == CURLE_OK) {
 		event->callback_error = error;
 	}
 
-	/* Also on the handle, which outlives the event: curl_async_perform() reads it
-	 * after the suspend that the exception ends, when the event may be gone. */
+	/* And on the handle, which outlives the event: curl_async_perform() reads it
+	 * after the suspend, by when the event may be gone. */
 	if (event->ch != NULL && event->ch->err.no == CURLE_OK) {
 		SAVE_CURL_ERROR(event->ch, error);
 	}
@@ -240,10 +238,8 @@ void curl_async_free_cb(void *arg);
  * @brief Seek callback for a CURLFile part, passed to curl_mime_data_cb().
  *
  * @param arg    Pointer to mime_data_cb_arg_t.
- * @param offset Target position, in the sense given by origin.
  * @param origin SEEK_SET, SEEK_CUR or SEEK_END.
- * @return CURL_SEEKFUNC_OK, or CURL_SEEKFUNC_CANTSEEK when the part cannot be
- *         replayed from that position.
+ * @return CURL_SEEKFUNC_CANTSEEK when the part cannot be replayed from there.
  */
 int curl_async_seek_cb(void *arg, curl_off_t offset, int origin);
 

--- a/ext/curl/curl_async.h
+++ b/ext/curl/curl_async.h
@@ -224,6 +224,17 @@ size_t curl_async_read_cb(char *buffer, size_t size, size_t nitems, void *arg);
 void curl_async_free_cb(void *arg);
 
 /**
+ * @brief Seek callback for a CURLFile part, passed to curl_mime_data_cb().
+ *
+ * @param arg    Pointer to mime_data_cb_arg_t.
+ * @param offset Target position, in the sense given by origin.
+ * @param origin SEEK_SET, SEEK_CUR or SEEK_END.
+ * @return CURL_SEEKFUNC_OK, or CURL_SEEKFUNC_CANTSEEK when the part cannot be
+ *         replayed from that position.
+ */
+int curl_async_seek_cb(void *arg, curl_off_t offset, int origin);
+
+/**
  * @brief Async write callback for PHP_CURL_FILE mode (body and headers).
  *
  * Uses the stream's async IO handle to write data asynchronously.

--- a/ext/curl/curl_async.h
+++ b/ext/curl/curl_async.h
@@ -54,17 +54,30 @@ typedef struct curl_async_event_s {
 	curl_async_write_state_t *write_state;        /* heap-allocated, NULL until first async write */
 	curl_async_write_state_t *header_write_state; /* same, for header writes */
 	zend_object *callback_exception;       /* exception from user callback, forwarded on completion */
+	CURLcode callback_error;               /* code that callback would have made libcurl report */
 } curl_async_event_t;
 
 /* Store a callback exception on the event, chaining via "previous" if one
  * already exists.  Caller must have already addref'd `exception`. */
 static zend_always_inline void curl_async_event_set_callback_exception(
-	curl_async_event_t *event, zend_object *exception
-) {
+	curl_async_event_t *event, zend_object *exception, const CURLcode error)
+{
 	if (event->callback_exception != NULL && event->callback_exception != exception) {
 		zend_exception_set_previous(exception, event->callback_exception);
 	}
 	event->callback_exception = exception;
+	/* The transfer reports what the callback would have made libcurl report: a
+	 * write or header callback answers CURLE_WRITE_ERROR, a read one
+	 * CURLE_ABORTED_BY_CALLBACK. The first to throw decides. */
+	if (event->callback_error == CURLE_OK) {
+		event->callback_error = error;
+	}
+
+	/* Also on the handle, which outlives the event: curl_async_perform() reads it
+	 * after the suspend that the exception ends, when the event may be gone. */
+	if (event->ch != NULL && event->ch->err.no == CURLE_OK) {
+		SAVE_CURL_ERROR(event->ch, error);
+	}
 }
 
 /* Read source type */

--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -1526,7 +1526,7 @@ static inline zend_result build_mime_structure_from_hash(php_curl *ch, zval *zpo
 
 				if ((form_error = curl_mime_name(part, ZSTR_VAL(string_key))) != CURLE_OK
 					|| (form_error = curl_mime_data_cb(part, filesize,
-						curl_async_read_cb, NULL, curl_async_free_cb, cb_arg)) != CURLE_OK
+						curl_async_read_cb, curl_async_seek_cb, curl_async_free_cb, cb_arg)) != CURLE_OK
 					|| (form_error = curl_mime_filename(part, filename ? filename : ZSTR_VAL(postval))) != CURLE_OK
 					|| (form_error = curl_mime_type(part, type ? type : "application/octet-stream")) != CURLE_OK) {
 					error = form_error;

--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -693,7 +693,7 @@ static int curl_progress(void *clientp, double dltotal, double dlnow, double ult
 	if (EG(exception) && ch->async_event != NULL) {
 		curl_async_event_t *curl_event = (curl_async_event_t *) ch->async_event;
 		GC_ADDREF(EG(exception));
-		curl_async_event_set_callback_exception(curl_event, EG(exception));
+		curl_async_event_set_callback_exception(curl_event, EG(exception), CURLE_ABORTED_BY_CALLBACK);
 		zend_clear_exception();
 		rval = 1;
 	}
@@ -743,7 +743,7 @@ static int curl_xferinfo(void *clientp, curl_off_t dltotal, curl_off_t dlnow, cu
 	if (EG(exception) && ch->async_event != NULL) {
 		curl_async_event_t *curl_event = (curl_async_event_t *) ch->async_event;
 		GC_ADDREF(EG(exception));
-		curl_async_event_set_callback_exception(curl_event, EG(exception));
+		curl_async_event_set_callback_exception(curl_event, EG(exception), CURLE_ABORTED_BY_CALLBACK);
 		zend_clear_exception();
 		rval = 1;
 	}
@@ -803,7 +803,7 @@ static int curl_prereqfunction(void *clientp, char *conn_primary_ip, char *conn_
 	if (EG(exception) && ch->async_event != NULL) {
 		curl_async_event_t *curl_event = (curl_async_event_t *) ch->async_event;
 		GC_ADDREF(EG(exception));
-		curl_async_event_set_callback_exception(curl_event, EG(exception));
+		curl_async_event_set_callback_exception(curl_event, EG(exception), CURLE_ABORTED_BY_CALLBACK);
 		zend_clear_exception();
 		rval = CURL_PREREQFUNC_ABORT;
 	}
@@ -977,7 +977,7 @@ static int curl_seek(void *clientp, curl_off_t offset, int origin)
 	if (EG(exception) && ch->async_event != NULL) {
 		curl_async_event_t *curl_event = (curl_async_event_t *) ch->async_event;
 		GC_ADDREF(EG(exception));
-		curl_async_event_set_callback_exception(curl_event, EG(exception));
+		curl_async_event_set_callback_exception(curl_event, EG(exception), CURLE_SEND_FAIL_REWIND);
 		zend_clear_exception();
 		rval = CURL_SEEKFUNC_FAIL;
 	}
@@ -1097,7 +1097,7 @@ static int curl_debug(CURL *handle, curl_infotype type, char *data, size_t size,
 	if (EG(exception) && ch->async_event != NULL) {
 		curl_async_event_t *curl_event = (curl_async_event_t *) ch->async_event;
 		GC_ADDREF(EG(exception));
-		curl_async_event_set_callback_exception(curl_event, EG(exception));
+		curl_async_event_set_callback_exception(curl_event, EG(exception), CURLE_ABORTED_BY_CALLBACK);
 		zend_clear_exception();
 	}
 


### PR DESCRIPTION
`ext/curl/tests` had four failures on this tree, unrelated to any async issue on the
tracker and failing the same way on a build of `true-async` without any of my recent
commits. Three defects behind them, one commit each.

## A CURLFile part could not be rewound

`curl_mime_data_cb()` was given `NULL` where libcurl expects a seek callback, so a
part whose body had already been read could not be replayed. A redirect ended the
transfer with `CURLE_ABORTED_BY_CALLBACK`, and `curl_curlfile_seek.phpt` printed
nothing where it expects `curl_testdata1.txt|application/octet-stream|6`.

Upstream carries this callback. The fork lost it when the CURLFile stream was made
lazy: with nothing open at registration time there was nothing for a seek to act
on, and the argument was passed as `NULL`. The new one seeks the stream the read
callback opened, and answers `CURL_SEEKFUNC_CANTSEEK` where the part cannot be
replayed — with a read in flight, whose completion would land at the position being
left. A finished read holds bytes from the old position and is released; the flags a
finished or failed read left are cleared.

## curl_errno() said nothing about a callback that threw

An exception from `CURLOPT_WRITEFUNCTION` or `CURLOPT_HEADERFUNCTION` left the
handle reporting `CURLE_OK`, and every other callback reported
`CURLE_ABORTED_BY_CALLBACK` whatever it was.
`curl_writefunction_throws_abort.phpt` and `curl_headerfunction_throws_abort.phpt`
assert `CURLE_WRITE_ERROR` and were red.

Upstream has no such gap: the callback returns to libcurl and libcurl decides. Here
the exception is stored and the transfer is torn down beside libcurl, so the code
has to be carried. It is now stored with the exception — `CURLE_WRITE_ERROR` for a
write or header callback, `CURLE_SEND_FAIL_REWIND` for a seek one,
`CURLE_ABORTED_BY_CALLBACK` for the rest — and the first callback to throw decides.

It is stored twice, on the event and on the handle, because the two readers live at
different times: the completion paths read the event while it is alive, and
`curl_async_perform()` reads after the suspend the exception ends, by which point
the notification may already have disposed the event. An earlier draft of this
change read it from the event there and it was a use-after-free; the two-store shape
is what the test caught.

## An empty upload aborted the next transfer

`CURLOPT_READFUNCTION` set back to `null` with no `CURLOPT_INFILE` behind it leaves
the read dispatch with no descriptor, and it answered `CURL_READFUNC_ABORT`. The
second `curl_exec()` in `curl_readfunction_throws_abort.phpt` therefore failed where
it had nothing to send. Upstream returns 0 in that case, which is an empty body. An
abort stays the answer where a source was named and turned out unusable.

## Checks

| build | suites | result |
|---|---|---|
| libcurl 8.12.1, ZTS debug | `ext/curl/tests` + `ext/async/tests` | 1367 passed, 0 failed |
| libcurl 8.12.1, ZTS ASAN | `ext/curl/tests` + `ext/async/tests/curl` | 240 passed, 0 failed |
| libcurl 8.5.0 (what the Linux CI builds) | same two curl suites | 235 passed, 0 failed |
| libcurl 7.87.0 (the minimum `config.m4` admits) | same | 233 passed, 0 failed |

`ext/async/fuzzy-tests/_generated` — 724 passed, 0 failed. Before these commits
`ext/curl/tests` was 168 passed, 4 failed on 8.12.1 and 164 passed, 4 failed on 8.5.0.