### PR TITLE
#299: Hand a throwing fnmatch or host-key callback to the coroutine

### DIFF
--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -646,10 +646,11 @@ static int curl_fnmatch(void *ctx, const char *pattern, const char *string)
 
 	/* Capture an exception from the user callback onto the async event so it is
 	 * delivered through the coroutine to the awaiter.  Without this, EG(exception)
-	 * stays set across further libcurl iterations and escapes outside the
-	 * coroutine as an uncaught error.  libcurl has no result code for a failing
-	 * fnmatch callback, it only tells a match from a non-match, so the transfer
-	 * reports the generic abort instead. */
+	 * stays set across further libcurl iterations and escapes outside the coroutine
+	 * as an uncaught error.  The result is overwritten because a warning raised as
+	 * an exception leaves the callback's own answer in rval.  libcurl has no code
+	 * for a failing fnmatch callback, only match and non-match, so the transfer
+	 * reports the generic abort. */
 	if (EG(exception) && ch->async_event != NULL) {
 		curl_async_event_t *curl_event = (curl_async_event_t *) ch->async_event;
 		GC_ADDREF(EG(exception));
@@ -871,9 +872,10 @@ static int curl_ssh_hostkeyfunction(void *clientp, int keytype, const char *key,
 	}
 
 	/* Same handoff as the other callbacks: the exception is carried on the event
-	 * rather than left in EG(exception) past the transfer.  A key the callback
-	 * refuses fails verification, which is what libcurl reports for anything but
-	 * CURLKHMATCH_OK. */
+	 * rather than left in EG(exception) past the transfer.  It takes a throw from
+	 * the callback and the wrong-return error above alike, and overwrites the
+	 * result in both, since either can leave the callback's own answer in rval.
+	 * Anything but CURLKHMATCH_OK fails verification in libcurl. */
 	if (EG(exception) && ch->async_event != NULL) {
 		curl_async_event_t *curl_event = (curl_async_event_t *) ch->async_event;
 		GC_ADDREF(EG(exception));

--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -643,6 +643,21 @@ static int curl_fnmatch(void *ctx, const char *pattern, const char *string)
 		/* TODO Check callback returns an int or something castable to int */
 		rval = php_curl_get_long(&retval);
 	}
+
+	/* Capture an exception from the user callback onto the async event so it is
+	 * delivered through the coroutine to the awaiter.  Without this, EG(exception)
+	 * stays set across further libcurl iterations and escapes outside the
+	 * coroutine as an uncaught error.  libcurl has no result code for a failing
+	 * fnmatch callback, it only tells a match from a non-match, so the transfer
+	 * reports the generic abort instead. */
+	if (EG(exception) && ch->async_event != NULL) {
+		curl_async_event_t *curl_event = (curl_async_event_t *) ch->async_event;
+		GC_ADDREF(EG(exception));
+		curl_async_event_set_callback_exception(curl_event, EG(exception), CURLE_ABORTED_BY_CALLBACK);
+		zend_clear_exception();
+		rval = CURL_FNMATCHFUNC_FAIL;
+	}
+
 	zval_ptr_dtor(&argv[0]);
 	zval_ptr_dtor(&argv[1]);
 	zval_ptr_dtor(&argv[2]);
@@ -853,6 +868,18 @@ static int curl_ssh_hostkeyfunction(void *clientp, int keytype, const char *key,
 			zend_throw_error(NULL, "The CURLOPT_SSH_HOSTKEYFUNCTION callback must return either CURLKHMATCH_OK or CURLKHMATCH_MISMATCH");
 			zval_ptr_dtor(&retval);
 		}
+	}
+
+	/* Same handoff as the other callbacks: the exception is carried on the event
+	 * rather than left in EG(exception) past the transfer.  A key the callback
+	 * refuses fails verification, which is what libcurl reports for anything but
+	 * CURLKHMATCH_OK. */
+	if (EG(exception) && ch->async_event != NULL) {
+		curl_async_event_t *curl_event = (curl_async_event_t *) ch->async_event;
+		GC_ADDREF(EG(exception));
+		curl_async_event_set_callback_exception(curl_event, EG(exception), CURLE_PEER_FAILED_VERIFICATION);
+		zend_clear_exception();
+		rval = CURLKHMATCH_MISMATCH;
 	}
 
 	zval_ptr_dtor(&args[0]);


### PR DESCRIPTION
Closes true-async/php-async#299.

`CURLOPT_FNMATCH_FUNCTION` and `CURLOPT_SSH_HOSTKEYFUNCTION` were the last two curl callbacks without the async exception handoff that `curl_prereqfunction`, `curl_debug`, `curl_progress` and `curl_xferinfo` already have. An exception left in `EG(exception)` survived the remaining libcurl iterations and escaped outside the coroutine as an uncaught fatal error, while the awaiter was woken with `Async\AsyncCancellation: Graceful shutdown`.

Both callbacks now store the exception on the async event with the code libcurl would have produced had the callback returned instead of thrown:

- fnmatch reports the generic abort. libcurl distinguishes only a match from a non-match there and has no result code for a failing callback (`lib/ftplistparser.c`, `ftp_pl_insert_finfo`).
- a refused host key reports `CURLE_PEER_FAILED_VERIFICATION`, which is what libcurl reports for anything but `CURLKHMATCH_OK` (`lib/vssh/libssh2.c`).

## Testing

- `ext/async/tests/curl/072-fnmatch_exception.phpt` (php-async PR) covers the fnmatch half against the FTP server from `ext/ftp/tests/server.inc`. Red before the change, green after; the failing diff shows both the wrong exception at the awaiter and the uncaught fatal.
- `ext/curl/tests` + `ext/async/tests` + `ext/async/fuzzy-tests/_generated`, ZTS debug, libcurl 8.12.1: 2116 passed, 0 failed.
- `ext/curl/interface.c` compiles clean against libcurl 8.5.0 and 7.87.0.

The host-key half has no test: the libcurl on the development machine carries neither `sftp` nor `scp`, so the callback cannot be reached there.
</body>
